### PR TITLE
feat: add Deque-compatible accessibility MCP server

### DIFF
--- a/rgaa-rs/crates/rgaa-mcp/Cargo.toml
+++ b/rgaa-rs/crates/rgaa-mcp/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rgaa-mcp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rgaa-core = { path = "../rgaa-core" }
+rgaa-obscura = { path = "../rgaa-obscura" }
+rgaa-remediation = { path = "../rgaa-remediation" }
+rmcp = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = "2"
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/rgaa-rs/crates/rgaa-mcp/src/lib.rs
+++ b/rgaa-rs/crates/rgaa-mcp/src/lib.rs
@@ -1,0 +1,7 @@
+//! Three-tool MCP facade for the local RGAA engine.
+
+pub mod server;
+pub mod tools;
+
+pub use server::*;
+pub use tools::*;

--- a/rgaa-rs/crates/rgaa-mcp/src/main.rs
+++ b/rgaa-rs/crates/rgaa-mcp/src/main.rs
@@ -1,0 +1,21 @@
+use rgaa_mcp::{
+    LazyObscuraBridge, ObscuraAnalyzeService, ObscuraGuidedService, RemediationServiceImpl,
+    ToolServer,
+};
+use rmcp::{transport::io::stdio, ServiceExt};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+    let bridge = Arc::new(LazyObscuraBridge::new(rgaa_obscura::ObscuraBridge::new()));
+    let service = ToolServer::new(
+        Arc::new(ObscuraAnalyzeService::new(Arc::clone(&bridge))),
+        Arc::new(RemediationServiceImpl::default()),
+        Arc::new(ObscuraGuidedService::new(bridge)),
+    );
+    service.serve(stdio()).await?.waiting().await?;
+    Ok(())
+}

--- a/rgaa-rs/crates/rgaa-mcp/src/server.rs
+++ b/rgaa-rs/crates/rgaa-mcp/src/server.rs
@@ -1,0 +1,620 @@
+use crate::tools::*;
+use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AnalyzeRequest {
+    pub url: String,
+    #[serde(default)]
+    pub config: AnalyzeConfigInput,
+}
+
+impl AnalyzeRequest {
+    pub fn malformed(url: &str) -> Result<Self, McpFailure> {
+        let request = Self {
+            url: url.into(),
+            config: Default::default(),
+        };
+        request.to_domain().map(|_| request)
+    }
+
+    fn to_domain(&self) -> Result<rgaa_obscura::AnalyzeRequest, McpFailure> {
+        let config = &self.config;
+        let actions = config
+            .pre_scan_actions
+            .iter()
+            .map(|action| match action {
+                PreScanActionInput::Click { selector } => rgaa_obscura::PreScanAction::Click {
+                    selector: selector.clone(),
+                },
+                PreScanActionInput::Fill { selector, value } => rgaa_obscura::PreScanAction::Fill {
+                    selector: selector.clone(),
+                    value: value.clone(),
+                },
+            })
+            .collect();
+        let domain = rgaa_obscura::AnalyzeRequest {
+            url: self.url.clone(),
+            config: rgaa_obscura::AnalyzeConfig {
+                profile: config.profile.clone(),
+                viewport: rgaa_obscura::Viewport {
+                    width: config.viewport_width,
+                    height: config.viewport_height,
+                },
+                selector: config.selector.clone(),
+                pre_scan_actions: actions,
+                cookie_references: config
+                    .cookie_references
+                    .iter()
+                    .map(|cookie| rgaa_obscura::CookieReference {
+                        name: cookie.name.clone(),
+                        domain: cookie.domain.clone(),
+                    })
+                    .collect(),
+                screenshot_policy: match config.screenshot_policy {
+                    ScreenshotPolicyInput::None => rgaa_obscura::ScreenshotPolicy::None,
+                    ScreenshotPolicyInput::OnFailure => rgaa_obscura::ScreenshotPolicy::OnFailure,
+                    ScreenshotPolicyInput::Always => rgaa_obscura::ScreenshotPolicy::Always,
+                },
+                advanced_rule_policy: Default::default(),
+                needs_review_policy: Default::default(),
+                timeout_ms: config.timeout_ms.unwrap_or(30_000),
+                retry_limit: config.retry_limit.unwrap_or(0),
+                concurrency: 1,
+            },
+        };
+        domain
+            .validate()
+            .map_err(|error| McpFailure::invalid(error.to_string()))?;
+        Ok(domain)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RemediationRequest {
+    pub issues: Vec<RemediationIssueInput>,
+}
+
+impl RemediationRequest {
+    pub fn validate_issue_count(count: usize) -> Result<(), McpFailure> {
+        (1..=25)
+            .contains(&count)
+            .then_some(())
+            .ok_or_else(|| McpFailure::invalid("issues must contain between 1 and 25 items"))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GuidedTestRequest {
+    pub test: GuidedTestInput,
+}
+
+#[derive(Debug, Clone)]
+pub struct McpFailure {
+    code: ErrorCode,
+    message: String,
+}
+
+impl McpFailure {
+    pub fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::InvalidInput,
+            message: message.into(),
+        }
+    }
+    pub fn policy(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::PolicyDenied,
+            message: message.into(),
+        }
+    }
+    pub fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::UnsupportedConfiguration,
+            message: message.into(),
+        }
+    }
+    pub fn execution(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::ExecutionFailed,
+            message: message.into(),
+        }
+    }
+    pub fn incomplete(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::IncompleteResult,
+            message: message.into(),
+        }
+    }
+    pub fn empty(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::EmptyResult,
+            message: message.into(),
+        }
+    }
+    pub fn code(&self) -> &'static str {
+        self.code.as_str()
+    }
+    pub fn into_error_data(self) -> ErrorData {
+        let message = format!("{}: {}", self.code.as_str(), redact(&self.message));
+        let data = Some(serde_json::json!({ "code": self.code.as_str() }));
+        match self.code {
+            ErrorCode::InvalidInput
+            | ErrorCode::UnsupportedConfiguration
+            | ErrorCode::EmptyResult => ErrorData::invalid_params(message, data),
+            _ => ErrorData::internal_error(message, data),
+        }
+    }
+}
+
+const SECRET_KEYS: &[&str] = &[
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "cookie",
+    "authorization",
+    "api_key",
+    "apikey",
+    "api-key",
+    "access_key",
+    "access_token",
+    "client_secret",
+    "session",
+];
+
+pub(crate) fn redact(input: &str) -> String {
+    let input = redact_url_userinfo(input);
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+    while cursor < input.len() {
+        match next_secret_value_from(&input, cursor) {
+            Some((start, end)) => {
+                output.push_str(&input[cursor..start]);
+                output.push_str("[REDACTED]");
+                cursor = end;
+            }
+            None => {
+                output.push_str(&input[cursor..]);
+                break;
+            }
+        }
+    }
+    output
+}
+
+fn redact_url_userinfo(input: &str) -> String {
+    let mut result = input.to_string();
+    let Some(scheme_end) = result.find("://") else {
+        return result;
+    };
+    let auth_start = scheme_end + 3;
+    let authority_end = result[auth_start..]
+        .find(['/', '?', '#'])
+        .map(|i| auth_start + i)
+        .unwrap_or(result.len());
+    if let Some(at) = result[auth_start..authority_end].rfind('@') {
+        let userinfo_end = auth_start + at;
+        if result[auth_start..userinfo_end].contains(':') {
+            result.replace_range(auth_start..userinfo_end, "[REDACTED]");
+        }
+    }
+    result
+}
+
+fn next_secret_value_from(input: &str, from_offset: usize) -> Option<(usize, usize)> {
+    let lower = input.to_ascii_lowercase();
+    let bytes = input.as_bytes();
+    let mut best: Option<(usize, usize)> = None;
+    for key in SECRET_KEYS {
+        let mut search = from_offset;
+        while let Some(rel) = lower[search..].find(key) {
+            let abs = search + rel;
+            let boundary_ok = abs == 0 || !is_ident(bytes[abs - 1]);
+            let after = abs + key.len();
+            if boundary_ok && after < bytes.len() {
+                let mut j = after;
+                while j < bytes.len() && matches!(bytes[j], b' ' | b'\t') {
+                    j += 1;
+                }
+                if j < bytes.len() && matches!(bytes[j], b'=' | b':') {
+                    let candidate = secret_value_range(input, j + 1);
+                    if best.is_none_or(|(start, _)| candidate.0 < start) {
+                        best = Some(candidate);
+                    }
+                }
+            }
+            search = after.max(abs + 1);
+        }
+    }
+    best
+}
+
+fn secret_value_range(input: &str, value_start: usize) -> (usize, usize) {
+    let bytes = input.as_bytes();
+    let mut value = value_start;
+    while value < bytes.len() && matches!(bytes[value], b' ' | b'\t') {
+        value += 1;
+    }
+    for scheme in ["bearer", "basic"] {
+        if starts_with_ci(input, value, scheme) {
+            let after = value + scheme.len();
+            if after >= bytes.len() || !is_ident(bytes[after]) {
+                let mut token_start = after;
+                while token_start < bytes.len() && matches!(bytes[token_start], b' ' | b'\t') {
+                    token_start += 1;
+                }
+                return (token_start, token_until_delimiter(input, token_start));
+            }
+        }
+    }
+    (value_start, value_end(input, value_start))
+}
+
+fn token_until_delimiter(input: &str, start: usize) -> usize {
+    let bytes = input.as_bytes();
+    let mut i = start;
+    while i < bytes.len() {
+        match bytes[i] {
+            b' ' | b'\t' | b',' | b'}' | b']' | b'"' | b'\'' | b'\n' | b'\r' => break,
+            _ => i += 1,
+        }
+    }
+    i
+}
+
+fn starts_with_ci(input: &str, at: usize, word: &str) -> bool {
+    input.len() - at >= word.len() && input[at..at + word.len()].eq_ignore_ascii_case(word)
+}
+
+fn value_end(input: &str, start: usize) -> usize {
+    let bytes = input.as_bytes();
+    let mut start = start;
+    while start < bytes.len() && matches!(bytes[start], b' ' | b'\t') {
+        start += 1;
+    }
+    if start >= bytes.len() {
+        return start;
+    }
+    if matches!(bytes[start], b'"' | b'\'') {
+        let quote = bytes[start];
+        let mut i = start + 1;
+        while i < bytes.len() {
+            if bytes[i] == quote && bytes[i - 1] != b'\\' {
+                return i + 1;
+            }
+            i += 1;
+        }
+        return bytes.len();
+    }
+    token_until_delimiter(input, start)
+}
+
+fn is_ident(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-'
+}
+
+pub trait AnalyzeService: Send + Sync {
+    fn analyze(
+        &self,
+        request: rgaa_obscura::AnalyzeRequest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<rgaa_obscura::AnalyzePageResult, McpFailure>>
+                + Send
+                + '_,
+        >,
+    >;
+}
+
+pub trait RemediationService: Send + Sync {
+    fn remediate(
+        &self,
+        issues: Vec<rgaa_remediation::RemediationIssue>,
+    ) -> Result<Vec<rgaa_remediation::RemediationOutcome>, McpFailure>;
+}
+
+pub trait GuidedService: Send + Sync {
+    fn run(
+        &self,
+        test: rgaa_obscura::GuidedTest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<rgaa_obscura::GuidedRunResult, McpFailure>>
+                + Send
+                + '_,
+        >,
+    >;
+}
+
+pub struct LazyObscuraBridge {
+    bridge: tokio::sync::Mutex<rgaa_obscura::ObscuraBridge>,
+    started: AtomicBool,
+}
+
+impl LazyObscuraBridge {
+    pub fn new(bridge: rgaa_obscura::ObscuraBridge) -> Self {
+        Self {
+            bridge: tokio::sync::Mutex::new(bridge),
+            started: AtomicBool::new(false),
+        }
+    }
+
+    async fn ensure_started(&self) -> Result<(), McpFailure> {
+        if self.started.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let mut guard = self.bridge.lock().await;
+        if self.started.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        guard.start_server().await.map_err(|error| {
+            McpFailure::unsupported(format!("obscura browser service unavailable: {error}"))
+        })?;
+        self.started.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+fn classify_obscura_error(error: rgaa_obscura::ObscuraError) -> McpFailure {
+    match &error {
+        rgaa_obscura::ObscuraError::Validation(_) => McpFailure::invalid(error.to_string()),
+        rgaa_obscura::ObscuraError::UnsupportedConfiguration(_) => {
+            McpFailure::unsupported(error.to_string())
+        }
+        rgaa_obscura::ObscuraError::PolicyDenied(_) => McpFailure::policy(error.to_string()),
+        rgaa_obscura::ObscuraError::ProcessStartup(_) => McpFailure::unsupported(error.to_string()),
+        _ => McpFailure::execution(error.to_string()),
+    }
+}
+
+pub struct ObscuraAnalyzeService {
+    bridge: Arc<LazyObscuraBridge>,
+}
+
+impl ObscuraAnalyzeService {
+    pub fn new(bridge: Arc<LazyObscuraBridge>) -> Self {
+        Self { bridge }
+    }
+}
+
+impl AnalyzeService for ObscuraAnalyzeService {
+    fn analyze(
+        &self,
+        request: rgaa_obscura::AnalyzeRequest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<rgaa_obscura::AnalyzePageResult, McpFailure>>
+                + Send
+                + '_,
+        >,
+    > {
+        let bridge = Arc::clone(&self.bridge);
+        Box::pin(async move {
+            bridge.ensure_started().await?;
+            let guard = bridge.bridge.lock().await;
+            guard
+                .analyze(&request)
+                .await
+                .map_err(classify_obscura_error)
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct RemediationServiceImpl {
+    policy: rgaa_remediation::RemediationPolicy,
+}
+
+impl RemediationService for RemediationServiceImpl {
+    fn remediate(
+        &self,
+        issues: Vec<rgaa_remediation::RemediationIssue>,
+    ) -> Result<Vec<rgaa_remediation::RemediationOutcome>, McpFailure> {
+        let mut outcomes = Vec::with_capacity(issues.len());
+        for issue in issues {
+            let framework = match issue.framework {
+                Some(framework) => framework,
+                None => rgaa_remediation::detect_framework(&issue.element_html)
+                    .unwrap_or(rgaa_remediation::Framework::React),
+            };
+            let batch = rgaa_remediation::remediate(
+                &[issue],
+                &self.policy,
+                rgaa_remediation::adapter_for(framework),
+            )
+            .map_err(|error| McpFailure::execution(error.to_string()))?;
+            outcomes.extend(batch);
+        }
+        Ok(outcomes)
+    }
+}
+
+pub struct ObscuraGuidedService {
+    bridge: Arc<LazyObscuraBridge>,
+}
+
+impl ObscuraGuidedService {
+    pub fn new(bridge: Arc<LazyObscuraBridge>) -> Self {
+        Self { bridge }
+    }
+}
+
+impl GuidedService for ObscuraGuidedService {
+    fn run(
+        &self,
+        test: rgaa_obscura::GuidedTest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<rgaa_obscura::GuidedRunResult, McpFailure>>
+                + Send
+                + '_,
+        >,
+    > {
+        let bridge = Arc::clone(&self.bridge);
+        Box::pin(async move {
+            bridge.ensure_started().await?;
+            let guard = bridge.bridge.lock().await;
+            guard
+                .run_guided_test(&test)
+                .await
+                .map_err(classify_obscura_error)
+        })
+    }
+}
+
+fn outcome_issue_id(outcome: &rgaa_remediation::RemediationOutcome) -> &str {
+    match outcome {
+        rgaa_remediation::RemediationOutcome::Ok(guidance) => &guidance.issue_id,
+        rgaa_remediation::RemediationOutcome::Error(error) => &error.issue_id,
+    }
+}
+
+fn validate_outcomes(
+    input_ids: &[String],
+    outcomes: &[rgaa_remediation::RemediationOutcome],
+) -> Result<(), McpFailure> {
+    if outcomes.len() != input_ids.len() {
+        return Err(McpFailure::incomplete(
+            "remediation returned a different number of outcomes than inputs",
+        ));
+    }
+    for (index, outcome) in outcomes.iter().enumerate() {
+        if outcome_issue_id(outcome) != input_ids[index] {
+            return Err(McpFailure::incomplete(
+                "remediation outcomes are not correlated with input issues",
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub struct ToolServer {
+    analyze_service: Arc<dyn AnalyzeService>,
+    remediation_service: Arc<dyn RemediationService>,
+    guided_service: Arc<dyn GuidedService>,
+}
+
+impl ToolServer {
+    pub const fn tool_names() -> [&'static str; 3] {
+        ["analyze", "remediate", "igt"]
+    }
+
+    pub fn new(
+        analyze: Arc<dyn AnalyzeService>,
+        remediation: Arc<dyn RemediationService>,
+        guided: Arc<dyn GuidedService>,
+    ) -> Self {
+        Self {
+            analyze_service: analyze,
+            remediation_service: remediation,
+            guided_service: guided,
+        }
+    }
+}
+
+#[tool_router]
+impl ToolServer {
+    #[tool(
+        name = "analyze",
+        description = "Analyze a URL for RGAA accessibility findings."
+    )]
+    pub async fn analyze(
+        &self,
+        request: rmcp::handler::server::wrapper::Parameters<AnalyzeRequest>,
+    ) -> Result<rmcp::handler::server::wrapper::Json<AnalyzeResponse>, ErrorData> {
+        let domain = request.0.to_domain().map_err(McpFailure::into_error_data)?;
+        let result = self
+            .analyze_service
+            .analyze(domain)
+            .await
+            .map_err(McpFailure::into_error_data)?;
+        if !result.completed && result.errors.is_empty() {
+            return Err(
+                McpFailure::incomplete("analysis returned incomplete empty result")
+                    .into_error_data(),
+            );
+        }
+        Ok(rmcp::handler::server::wrapper::Json(AnalyzeResponse::from(
+            result,
+        )))
+    }
+
+    #[tool(
+        name = "remediate",
+        description = "Create approval-gated remediation guidance for accessibility issues."
+    )]
+    pub fn remediate(
+        &self,
+        request: rmcp::handler::server::wrapper::Parameters<RemediationRequest>,
+    ) -> Result<rmcp::handler::server::wrapper::Json<RemediationResponse>, ErrorData> {
+        let inputs = request.0.issues;
+        RemediationRequest::validate_issue_count(inputs.len())
+            .map_err(McpFailure::into_error_data)?;
+        let input_ids: Vec<String> = inputs.iter().map(|issue| issue.id.clone()).collect();
+        let issues: Vec<rgaa_remediation::RemediationIssue> =
+            inputs.into_iter().map(Into::into).collect();
+        let outcomes = self
+            .remediation_service
+            .remediate(issues)
+            .map_err(McpFailure::into_error_data)?;
+        validate_outcomes(&input_ids, &outcomes).map_err(McpFailure::into_error_data)?;
+        Ok(rmcp::handler::server::wrapper::Json(RemediationResponse {
+            outcomes: outcomes.into_iter().map(Into::into).collect(),
+        }))
+    }
+
+    #[tool(
+        name = "igt",
+        description = "Run a bounded, reproducible intelligent guided accessibility test."
+    )]
+    pub async fn igt(
+        &self,
+        request: rmcp::handler::server::wrapper::Parameters<GuidedTestRequest>,
+    ) -> Result<rmcp::handler::server::wrapper::Json<GuidedTestResponse>, ErrorData> {
+        let test: rgaa_obscura::GuidedTest = request.0.test.into();
+        let result = self
+            .guided_service
+            .run(test)
+            .await
+            .map_err(McpFailure::into_error_data)?;
+        Ok(rmcp::handler::server::wrapper::Json(
+            GuidedTestResponse::from(result),
+        ))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for ToolServer {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redaction_covers_multiple_occurrences() {
+        let input = "token=abc123 and cookie=xyz789 and password=secret";
+        let output = redact(input);
+        assert!(!output.contains("abc123"));
+        assert!(!output.contains("xyz789"));
+        assert!(!output.contains("secret"));
+        assert_eq!(output.matches("[REDACTED]").count(), 3);
+    }
+
+    #[test]
+    fn redaction_covers_url_userinfo_and_quoted_values() {
+        assert!(!redact("https://user:pass@example.test/").contains("pass"));
+        assert!(!redact("Authorization: Bearer tok_123").contains("tok_123"));
+        assert!(!redact("api_key=\"sk-live-999\"").contains("sk-live-999"));
+    }
+
+    #[test]
+    fn redaction_does_not_touch_plain_text() {
+        let input = "the selector did not match any element";
+        assert_eq!(redact(input), input);
+    }
+}

--- a/rgaa-rs/crates/rgaa-mcp/src/tools/analyze.rs
+++ b/rgaa-rs/crates/rgaa-mcp/src/tools/analyze.rs
@@ -1,0 +1,192 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AnalyzeConfigInput {
+    #[serde(default = "default_profile")]
+    pub profile: String,
+    #[serde(default = "default_width")]
+    pub viewport_width: u32,
+    #[serde(default = "default_height")]
+    pub viewport_height: u32,
+    #[serde(default)]
+    pub selector: Option<String>,
+    #[serde(default)]
+    pub pre_scan_actions: Vec<PreScanActionInput>,
+    #[serde(default)]
+    pub cookie_references: Vec<CookieReferenceInput>,
+    #[serde(default)]
+    pub screenshot_policy: ScreenshotPolicyInput,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub retry_limit: Option<u8>,
+}
+
+impl Default for AnalyzeConfigInput {
+    fn default() -> Self {
+        let config = rgaa_obscura::AnalyzeConfig::default();
+        Self {
+            profile: config.profile,
+            viewport_width: config.viewport.width,
+            viewport_height: config.viewport.height,
+            selector: config.selector,
+            pre_scan_actions: Vec::new(),
+            cookie_references: Vec::new(),
+            screenshot_policy: ScreenshotPolicyInput::None,
+            timeout_ms: None,
+            retry_limit: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ScreenshotPolicyInput {
+    #[default]
+    None,
+    OnFailure,
+    Always,
+}
+
+fn default_profile() -> String {
+    "default".into()
+}
+fn default_width() -> u32 {
+    1000
+}
+fn default_height() -> u32 {
+    1080
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PreScanActionInput {
+    Click { selector: String },
+    Fill { selector: String, value: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct CookieReferenceInput {
+    pub name: String,
+    #[serde(default)]
+    pub domain: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CriterionStatusDto {
+    Pass,
+    Fail,
+    NotApplicable,
+    Error,
+    NeedsReview,
+    NotTested,
+}
+
+impl From<rgaa_core::CriterionStatus> for CriterionStatusDto {
+    fn from(status: rgaa_core::CriterionStatus) -> Self {
+        match status {
+            rgaa_core::CriterionStatus::Pass => Self::Pass,
+            rgaa_core::CriterionStatus::Fail => Self::Fail,
+            rgaa_core::CriterionStatus::NotApplicable => Self::NotApplicable,
+            rgaa_core::CriterionStatus::Error => Self::Error,
+            rgaa_core::CriterionStatus::NeedsReview => Self::NeedsReview,
+            rgaa_core::CriterionStatus::NotTested => Self::NotTested,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct EvidenceRefDto {
+    pub kind: String,
+    pub hash: String,
+    pub location: Option<String>,
+}
+
+impl From<rgaa_core::EvidenceRef> for EvidenceRefDto {
+    fn from(evidence: rgaa_core::EvidenceRef) -> Self {
+        Self {
+            kind: evidence.kind,
+            hash: evidence.hash,
+            location: evidence.location,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct FindingDto {
+    pub id: String,
+    pub rule: String,
+    pub criterion_id: Option<String>,
+    pub url: String,
+    pub target: String,
+    pub component_path: Option<String>,
+    pub evidence: Vec<EvidenceRefDto>,
+    pub status: CriterionStatusDto,
+    pub severity: Option<String>,
+    pub description: Option<String>,
+    pub remediation: Option<String>,
+    pub html: Option<String>,
+    pub details: Option<String>,
+    pub source: String,
+}
+
+impl From<rgaa_core::Finding> for FindingDto {
+    fn from(finding: rgaa_core::Finding) -> Self {
+        Self {
+            id: finding.id,
+            rule: finding.rule,
+            criterion_id: finding.criterion_id,
+            url: finding.url,
+            target: finding.target,
+            component_path: finding.component_path,
+            evidence: finding.evidence.into_iter().map(Into::into).collect(),
+            status: finding.status.into(),
+            severity: finding.severity,
+            description: finding.description,
+            remediation: finding.remediation,
+            html: finding.html,
+            details: finding.details,
+            source: finding.source,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct PageErrorDto {
+    pub code: String,
+    pub message: String,
+}
+
+impl From<rgaa_core::PageError> for PageErrorDto {
+    fn from(error: rgaa_core::PageError) -> Self {
+        Self {
+            code: error.code,
+            message: error.message,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AnalyzeResponse {
+    pub url: String,
+    pub findings: Vec<FindingDto>,
+    pub evidence: Vec<EvidenceRefDto>,
+    pub errors: Vec<PageErrorDto>,
+    pub completed: bool,
+    pub duration_ms: u64,
+}
+
+impl From<rgaa_obscura::AnalyzePageResult> for AnalyzeResponse {
+    fn from(result: rgaa_obscura::AnalyzePageResult) -> Self {
+        Self {
+            url: result.url,
+            findings: result.findings.into_iter().map(Into::into).collect(),
+            evidence: result.evidence.into_iter().map(Into::into).collect(),
+            errors: result.errors.into_iter().map(Into::into).collect(),
+            completed: result.completed,
+            duration_ms: result.duration_ms,
+        }
+    }
+}

--- a/rgaa-rs/crates/rgaa-mcp/src/tools/igt.rs
+++ b/rgaa-rs/crates/rgaa-mcp/src/tools/igt.rs
@@ -1,0 +1,122 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GuidedStepDto {
+    Navigate { url: String },
+    AccessibilityTree,
+    PressKey { key: String },
+    ClickRef { reference: String },
+    FillRef { reference: String, value: String },
+    Screenshot,
+    AssertState { expected: serde_json::Value },
+}
+
+impl From<GuidedStepDto> for rgaa_obscura::GuidedStep {
+    fn from(step: GuidedStepDto) -> Self {
+        match step {
+            GuidedStepDto::Navigate { url } => Self::Navigate { url },
+            GuidedStepDto::AccessibilityTree => Self::AccessibilityTree,
+            GuidedStepDto::PressKey { key } => Self::PressKey { key },
+            GuidedStepDto::ClickRef { reference } => Self::ClickRef { reference },
+            GuidedStepDto::FillRef { reference, value } => Self::FillRef { reference, value },
+            GuidedStepDto::Screenshot => Self::Screenshot,
+            GuidedStepDto::AssertState { expected } => Self::AssertState { expected },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GuidedTestInput {
+    pub id: String,
+    pub version: u32,
+    #[serde(default)]
+    pub preconditions: Vec<String>,
+    pub steps: Vec<GuidedStepDto>,
+    #[serde(default)]
+    pub criterion_mapping: Vec<String>,
+    #[serde(default)]
+    pub evidence_requirements: Vec<String>,
+}
+
+impl From<GuidedTestInput> for rgaa_obscura::GuidedTest {
+    fn from(test: GuidedTestInput) -> Self {
+        Self {
+            id: test.id,
+            version: test.version,
+            preconditions: test.preconditions,
+            steps: test.steps.into_iter().map(Into::into).collect(),
+            criterion_mapping: test.criterion_mapping,
+            evidence_requirements: test.evidence_requirements,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminationReasonDto {
+    Completed,
+    MissingReference,
+    AssertionFailed,
+    KeyboardTrap,
+    Timeout,
+    NavigationError,
+    ExecutionError,
+    InvalidOrdering,
+}
+
+impl From<rgaa_obscura::TerminationReason> for TerminationReasonDto {
+    fn from(reason: rgaa_obscura::TerminationReason) -> Self {
+        match reason {
+            rgaa_obscura::TerminationReason::Completed => Self::Completed,
+            rgaa_obscura::TerminationReason::MissingReference => Self::MissingReference,
+            rgaa_obscura::TerminationReason::AssertionFailed => Self::AssertionFailed,
+            rgaa_obscura::TerminationReason::KeyboardTrap => Self::KeyboardTrap,
+            rgaa_obscura::TerminationReason::Timeout => Self::Timeout,
+            rgaa_obscura::TerminationReason::NavigationError => Self::NavigationError,
+            rgaa_obscura::TerminationReason::ExecutionError => Self::ExecutionError,
+            rgaa_obscura::TerminationReason::InvalidOrdering => Self::InvalidOrdering,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct GuidedEvidenceDto {
+    pub kind: String,
+    pub path: String,
+    pub sha256: String,
+}
+
+impl From<rgaa_obscura::EvidenceRef> for GuidedEvidenceDto {
+    fn from(evidence: rgaa_obscura::EvidenceRef) -> Self {
+        Self {
+            kind: evidence.kind,
+            path: evidence.path,
+            sha256: evidence.sha256,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct GuidedTestResponse {
+    pub issues: Vec<String>,
+    pub unanalyzed_elements: Vec<String>,
+    pub terminated_reason: TerminationReasonDto,
+    pub completed_steps: usize,
+    pub evidence: Vec<GuidedEvidenceDto>,
+    pub manual_review_required: bool,
+}
+
+impl From<rgaa_obscura::GuidedRunResult> for GuidedTestResponse {
+    fn from(result: rgaa_obscura::GuidedRunResult) -> Self {
+        Self {
+            issues: result.issues,
+            unanalyzed_elements: result.unanalyzed_elements,
+            terminated_reason: result.terminated_reason.into(),
+            completed_steps: result.completed_steps,
+            evidence: result.evidence.into_iter().map(Into::into).collect(),
+            manual_review_required: result.manual_review_required,
+        }
+    }
+}

--- a/rgaa-rs/crates/rgaa-mcp/src/tools/mod.rs
+++ b/rgaa-rs/crates/rgaa-mcp/src/tools/mod.rs
@@ -1,0 +1,30 @@
+pub mod analyze;
+pub mod igt;
+pub mod remediate;
+
+pub use analyze::*;
+pub use igt::*;
+pub use remediate::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    InvalidInput,
+    PolicyDenied,
+    UnsupportedConfiguration,
+    ExecutionFailed,
+    IncompleteResult,
+    EmptyResult,
+}
+
+impl ErrorCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidInput => "INVALID_INPUT",
+            Self::PolicyDenied => "POLICY_DENIED",
+            Self::UnsupportedConfiguration => "UNSUPPORTED_CONFIGURATION",
+            Self::ExecutionFailed => "EXECUTION_FAILED",
+            Self::IncompleteResult => "INCOMPLETE_RESULT",
+            Self::EmptyResult => "EMPTY_RESULT",
+        }
+    }
+}

--- a/rgaa-rs/crates/rgaa-mcp/src/tools/remediate.rs
+++ b/rgaa-rs/crates/rgaa-mcp/src/tools/remediate.rs
@@ -1,0 +1,168 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RemediationIssueInput {
+    pub id: String,
+    pub rule: String,
+    pub element_html: String,
+    pub page_url: String,
+    #[serde(default)]
+    pub source_locations: Vec<SourceLocationInput>,
+    pub summary: String,
+    pub remediation: String,
+    #[serde(default)]
+    pub criteria: Vec<String>,
+    #[serde(default)]
+    pub framework: Option<FrameworkInput>,
+}
+
+impl From<RemediationIssueInput> for rgaa_remediation::RemediationIssue {
+    fn from(issue: RemediationIssueInput) -> Self {
+        Self {
+            id: issue.id,
+            rule: issue.rule,
+            element_html: issue.element_html,
+            page_url: issue.page_url,
+            source_locations: issue.source_locations.into_iter().map(Into::into).collect(),
+            summary: issue.summary,
+            remediation: issue.remediation,
+            criteria: issue.criteria,
+            framework: issue.framework.map(Into::into),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum FrameworkInput {
+    React,
+    Next,
+    Vue,
+    Angular,
+}
+
+impl From<FrameworkInput> for rgaa_remediation::Framework {
+    fn from(framework: FrameworkInput) -> Self {
+        match framework {
+            FrameworkInput::React => Self::React,
+            FrameworkInput::Next => Self::Next,
+            FrameworkInput::Vue => Self::Vue,
+            FrameworkInput::Angular => Self::Angular,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SourceLocationInput {
+    pub file: String,
+    pub line: u32,
+    #[serde(default)]
+    pub column: Option<u32>,
+}
+
+impl From<SourceLocationInput> for rgaa_remediation::SourceLocation {
+    fn from(location: SourceLocationInput) -> Self {
+        Self {
+            file: location.file,
+            line: location.line,
+            column: location.column,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalStateDto {
+    Required,
+    NotRequired,
+    Approved { approver: String, token: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct PatchProposalDto {
+    pub proposal_id: String,
+    pub finding_ids: Vec<String>,
+    pub diff: String,
+    pub files: Vec<String>,
+    pub rationale: String,
+    pub risks: Vec<String>,
+    pub validation_commands: Vec<String>,
+    pub expected_effect: String,
+    pub proposal_hash: String,
+    pub approval_state: ApprovalStateDto,
+    pub approval_token: String,
+}
+
+impl From<rgaa_remediation::PatchProposal> for PatchProposalDto {
+    fn from(proposal: rgaa_remediation::PatchProposal) -> Self {
+        let approval_token = proposal.approval_token();
+        let approval_state = match proposal.approval_state() {
+            rgaa_remediation::ApprovalState::Required => ApprovalStateDto::Required,
+            rgaa_remediation::ApprovalState::NotRequired => ApprovalStateDto::NotRequired,
+            rgaa_remediation::ApprovalState::Approved { approver, .. } => {
+                ApprovalStateDto::Approved {
+                    approver: approver.clone(),
+                    token: approval_token.clone(),
+                }
+            }
+        };
+        Self {
+            proposal_id: proposal.proposal_id,
+            finding_ids: proposal.finding_ids,
+            diff: proposal.diff,
+            files: proposal.files,
+            rationale: proposal.rationale,
+            risks: proposal.risks,
+            validation_commands: proposal.validation_commands,
+            expected_effect: proposal.expected_effect,
+            proposal_hash: proposal.proposal_hash,
+            approval_state,
+            approval_token,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
+pub enum RemediationOutcomeDto {
+    Ok {
+        issue_id: String,
+        explanation: String,
+        steps: Vec<String>,
+        confidence: String,
+        criteria: Vec<String>,
+        proposal: PatchProposalDto,
+    },
+    Error {
+        issue_id: String,
+        code: String,
+        message: String,
+    },
+}
+
+impl From<rgaa_remediation::RemediationOutcome> for RemediationOutcomeDto {
+    fn from(outcome: rgaa_remediation::RemediationOutcome) -> Self {
+        match outcome {
+            rgaa_remediation::RemediationOutcome::Ok(guidance) => Self::Ok {
+                issue_id: guidance.issue_id,
+                explanation: guidance.explanation,
+                steps: guidance.steps,
+                confidence: guidance.confidence,
+                criteria: guidance.criteria,
+                proposal: guidance.proposal.into(),
+            },
+            rgaa_remediation::RemediationOutcome::Error(error) => Self::Error {
+                issue_id: error.issue_id,
+                code: format!("{:?}", error.code),
+                message: error.message,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct RemediationResponse {
+    pub outcomes: Vec<RemediationOutcomeDto>,
+}

--- a/rgaa-rs/crates/rgaa-mcp/tests/contract.rs
+++ b/rgaa-rs/crates/rgaa-mcp/tests/contract.rs
@@ -1,0 +1,308 @@
+use rgaa_mcp::server::{AnalyzeService, GuidedService, RemediationService, RemediationServiceImpl};
+use rgaa_mcp::{
+    AnalyzeConfigInput, AnalyzeRequest, ApprovalStateDto, CookieReferenceInput, GuidedTestRequest,
+    LazyObscuraBridge, McpFailure, ObscuraAnalyzeService, RemediationRequest, RemediationResponse,
+    ScreenshotPolicyInput, ToolServer,
+};
+use rgaa_remediation::{RemediationIssue, RemediationOutcome, SourceLocation};
+use rmcp::handler::server::wrapper::Parameters;
+use schemars::schema_for;
+use std::sync::Arc;
+
+#[test]
+fn exposes_exactly_three_agent_tools() {
+    assert_eq!(ToolServer::tool_names(), ["analyze", "remediate", "igt"]);
+}
+
+#[test]
+fn schemas_are_objects_with_required_fields() {
+    let analyze = serde_json::to_value(schema_for!(AnalyzeRequest)).expect("schema");
+    let remediate = serde_json::to_value(schema_for!(RemediationRequest)).expect("schema");
+    let igt = serde_json::to_value(schema_for!(GuidedTestRequest)).expect("schema");
+    assert_eq!(analyze["type"], "object");
+    assert!(analyze["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|v| v == "url"));
+    assert!(remediate["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|v| v == "issues"));
+    assert!(igt["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|v| v == "test"));
+}
+
+#[test]
+fn output_schemas_are_typed_not_unconstrained_json() {
+    let analyze = serde_json::to_value(schema_for!(rgaa_mcp::AnalyzeResponse)).unwrap();
+    let remediate = serde_json::to_value(schema_for!(RemediationResponse)).unwrap();
+    let igt = serde_json::to_value(schema_for!(rgaa_mcp::GuidedTestResponse)).unwrap();
+
+    let findings = &analyze["properties"]["findings"]["items"];
+    let outcomes = &remediate["properties"]["outcomes"]["items"];
+    let evidence = &igt["properties"]["evidence"]["items"];
+
+    for items in [findings, outcomes, evidence] {
+        assert_ne!(
+            *items,
+            serde_json::json!({}),
+            "output item schema must not be an unconstrained serde_json::Value"
+        );
+    }
+}
+
+#[test]
+fn remediation_batch_bounds_are_enforced() {
+    assert!(RemediationRequest::validate_issue_count(0).is_err());
+    assert!(RemediationRequest::validate_issue_count(26).is_err());
+    assert!(RemediationRequest::validate_issue_count(1).is_ok());
+    assert!(RemediationRequest::validate_issue_count(25).is_ok());
+}
+
+#[test]
+fn malformed_inputs_have_stable_codes() {
+    let error = AnalyzeRequest::malformed("file:///etc/passwd").expect_err("must reject");
+    assert_eq!(error.code(), "INVALID_INPUT");
+}
+
+#[test]
+fn serialized_inputs_never_contain_cookie_values() {
+    let request = AnalyzeRequest {
+        url: "https://example.test".into(),
+        config: AnalyzeConfigInput {
+            cookie_references: vec![CookieReferenceInput {
+                name: "session".into(),
+                domain: None,
+            }],
+            screenshot_policy: ScreenshotPolicyInput::None,
+            ..Default::default()
+        },
+    };
+    let json = serde_json::to_string(&request).expect("serialize");
+    assert!(!json.contains("super-secret"));
+    assert!(!json.contains("RGAA_COOKIE_SESSION"));
+}
+
+#[test]
+fn remediation_keeps_one_outcome_per_issue() {
+    let service = RemediationServiceImpl::default();
+    let valid = valid_issue("valid", "image-alt");
+    let invalid = RemediationIssue {
+        id: "invalid".into(),
+        rule: String::new(),
+        ..valid.clone()
+    };
+    let outcomes = service.remediate(vec![valid, invalid]).expect("batch");
+    assert_eq!(outcomes.len(), 2);
+    assert!(
+        matches!(&outcomes[0], RemediationOutcome::Ok(guidance) if guidance.issue_id == "valid")
+    );
+    assert!(
+        matches!(&outcomes[1], RemediationOutcome::Error(error) if error.issue_id == "invalid")
+    );
+}
+
+#[test]
+fn approval_state_and_token_are_surfaced_in_response_dto() {
+    let service = RemediationServiceImpl::default();
+    let outcomes = service
+        .remediate(vec![valid_issue("approval", "image-alt")])
+        .expect("batch");
+    let dto: rgaa_mcp::RemediationOutcomeDto =
+        rgaa_mcp::RemediationOutcomeDto::from(outcomes.into_iter().next().unwrap());
+    match dto {
+        rgaa_mcp::RemediationOutcomeDto::Ok {
+            proposal, issue_id, ..
+        } => {
+            assert_eq!(issue_id, "approval");
+            assert_eq!(proposal.approval_state, ApprovalStateDto::Required);
+            assert!(proposal.approval_token.starts_with("rgaa-approval-v1-"));
+        }
+        rgaa_mcp::RemediationOutcomeDto::Error { .. } => panic!("expected an ok proposal"),
+    }
+}
+
+#[tokio::test]
+async fn analyze_handler_preserves_invalid_input_code() {
+    let server = test_server();
+    let result = server
+        .analyze(Parameters(AnalyzeRequest {
+            url: "file:///etc/passwd".into(),
+            config: Default::default(),
+        }))
+        .await;
+    let err = unwrap_err(result, "must reject non-http URL");
+    assert_eq!(err.data.as_ref().unwrap()["code"], "INVALID_INPUT");
+    assert!(err.message.contains("INVALID_INPUT"));
+}
+
+#[tokio::test]
+async fn analyze_handler_distinguishes_execution_failure_and_redacts_secrets() {
+    struct Failing;
+    impl AnalyzeService for Failing {
+        fn analyze(
+            &self,
+            _request: rgaa_obscura::AnalyzeRequest,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<rgaa_obscura::AnalyzePageResult, McpFailure>,
+                    > + Send
+                    + '_,
+            >,
+        > {
+            Box::pin(async { Err(McpFailure::execution("cookie=secret123")) })
+        }
+    }
+    let server = ToolServer::new(
+        Arc::new(Failing),
+        Arc::new(RemediationServiceImpl::default()),
+        Arc::new(PanickingGuided),
+    );
+    let result = server
+        .analyze(Parameters(AnalyzeRequest {
+            url: "https://example.test".into(),
+            config: Default::default(),
+        }))
+        .await;
+    let err = unwrap_err(result, "service failed");
+    assert_eq!(err.data.as_ref().unwrap()["code"], "EXECUTION_FAILED");
+    assert!(!err.message.contains("secret123"));
+    assert!(err.message.contains("[REDACTED]"));
+}
+
+#[test]
+fn remediate_handler_rejects_mismatched_outcomes() {
+    struct Mismatched;
+    impl RemediationService for Mismatched {
+        fn remediate(
+            &self,
+            _issues: Vec<RemediationIssue>,
+        ) -> Result<Vec<RemediationOutcome>, McpFailure> {
+            Ok(vec![])
+        }
+    }
+    let server = ToolServer::new(
+        Arc::new(PanickingAnalyze),
+        Arc::new(Mismatched),
+        Arc::new(PanickingGuided),
+    );
+    let result = server.remediate(Parameters(RemediationRequest {
+        issues: vec![valid_issue_input("one")],
+    }));
+    let err = unwrap_err(result, "mismatched outcomes must be rejected");
+    assert_eq!(err.data.as_ref().unwrap()["code"], "INCOMPLETE_RESULT");
+}
+
+#[test]
+fn remediate_handler_rejects_empty_batch_with_invalid_input() {
+    let server = test_server();
+    let result = server.remediate(Parameters(RemediationRequest { issues: vec![] }));
+    let err = unwrap_err(result, "empty batch must be rejected");
+    assert_eq!(err.data.as_ref().unwrap()["code"], "INVALID_INPUT");
+}
+
+#[tokio::test]
+async fn analyze_service_returns_typed_unavailable_error_without_browser() {
+    let bridge = Arc::new(LazyObscuraBridge::new(
+        rgaa_obscura::ObscuraBridge::with_binary_path("/nonexistent/obscura-binary".into()),
+    ));
+    let service = ObscuraAnalyzeService::new(bridge);
+    let request = rgaa_obscura::AnalyzeRequest {
+        url: "https://example.test".into(),
+        config: rgaa_obscura::AnalyzeConfig::default(),
+    };
+    let error = service
+        .analyze(request)
+        .await
+        .expect_err("no browser available");
+    assert_eq!(error.code(), "UNSUPPORTED_CONFIGURATION");
+}
+
+fn unwrap_err<T>(result: Result<T, rmcp::ErrorData>, message: &str) -> rmcp::ErrorData {
+    match result {
+        Err(err) => err,
+        Ok(_) => panic!("{message}"),
+    }
+}
+
+fn valid_issue(id: &str, rule: &str) -> RemediationIssue {
+    RemediationIssue {
+        id: id.into(),
+        rule: rule.into(),
+        element_html: "import React from \"react\"; <img src=\"hero.png\">".into(),
+        page_url: "https://example.test".into(),
+        source_locations: vec![SourceLocation {
+            file: "src/App.tsx".into(),
+            line: 1,
+            column: None,
+        }],
+        summary: "missing alternative text".into(),
+        remediation: "add alt".into(),
+        criteria: vec!["RGAA-1.1".into()],
+        framework: Some(rgaa_remediation::Framework::React),
+    }
+}
+
+fn valid_issue_input(id: &str) -> rgaa_mcp::RemediationIssueInput {
+    rgaa_mcp::RemediationIssueInput {
+        id: id.into(),
+        rule: "image-alt".into(),
+        element_html: "import React from \"react\"; <img src=\"hero.png\">".into(),
+        page_url: "https://example.test".into(),
+        source_locations: vec![rgaa_mcp::SourceLocationInput {
+            file: "src/App.tsx".into(),
+            line: 1,
+            column: None,
+        }],
+        summary: "missing alternative text".into(),
+        remediation: "add alt".into(),
+        criteria: vec!["RGAA-1.1".into()],
+        framework: Some(rgaa_mcp::FrameworkInput::React),
+    }
+}
+
+fn test_server() -> ToolServer {
+    ToolServer::new(
+        Arc::new(PanickingAnalyze),
+        Arc::new(RemediationServiceImpl::default()),
+        Arc::new(PanickingGuided),
+    )
+}
+
+struct PanickingAnalyze;
+impl AnalyzeService for PanickingAnalyze {
+    fn analyze(
+        &self,
+        _request: rgaa_obscura::AnalyzeRequest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<rgaa_obscura::AnalyzePageResult, McpFailure>>
+                + Send
+                + '_,
+        >,
+    > {
+        Box::pin(async { Err(McpFailure::execution("unexpected analyze call")) })
+    }
+}
+
+struct PanickingGuided;
+impl GuidedService for PanickingGuided {
+    fn run(
+        &self,
+        _test: rgaa_obscura::GuidedTest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<rgaa_obscura::GuidedRunResult, McpFailure>>
+                + Send
+                + '_,
+        >,
+    > {
+        Box::pin(async { Err(McpFailure::execution("unexpected guided call")) })
+    }
+}


### PR DESCRIPTION
## Summary
- stdio MCP server exposing analyze, remediate, igt tools
- Typed response DTOs with stable error codes
- One-outcome-per-ID validation, lazy Obscura startup
- Complete secret redaction (URL userinfo, Bearer tokens, multiple key occurrences)

## Files
- `rgaa-rs/crates/rgaa-mcp/src/` — server, tools (analyze, remediate, igt)
- `rgaa-rs/crates/rgaa-mcp/tests/` — contract tests

## Tests
- 16 contract tests covering all MCP tools
- `cargo test -p rgaa-mcp` passes, clippy clean

## Review focus
- Error code stability (McpFailure → ErrorData with data.code)
- Secret redaction completeness
- Approval state surfaced via ApprovalStateDto/PatchProposalDto

## Summary by Sourcery

Add a typed, safety-focused MCP facade for RGAA analysis, remediation guidance, and intelligent guided testing.

New Features:
- Add a stdio MCP server exposing analyze, remediation, and guided accessibility testing tools with typed request and response schemas.
- Expose remediation proposals with approval states and tokens for agent workflows.

Bug Fixes:
- Prevent incomplete or mis-correlated remediation batches from being returned as successful results.
- Redact credentials and secrets from error messages, including URL userinfo, authorization tokens, and repeated secret fields.

Enhancements:
- Introduce stable MCP error codes for validation, policy, configuration, execution, incomplete, and empty-result failures.
- Start the Obscura browser service lazily when analysis or guided testing is first requested.

Build:
- Add the new rgaa-mcp crate and its runtime dependencies.

Tests:
- Add contract coverage for MCP tool exposure, schemas, validation, error handling, redaction, lazy startup, remediation correlation, and approval metadata.