### PR TITLE
feat: add versioned audit contracts and Obscura analysis

### DIFF
--- a/rgaa-rs/Cargo.lock
+++ b/rgaa-rs/Cargo.lock
@@ -40,6 +40,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +290,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +419,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +512,12 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -421,6 +582,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -496,6 +672,7 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -588,6 +765,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -834,6 +1017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +1051,21 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -869,6 +1073,12 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -1083,10 +1293,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -1116,6 +1338,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1170,6 +1398,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
@@ -1350,6 +1584,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1683,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgaa-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "indicatif",
+ "rgaa-core",
+ "rgaa-obscura",
+ "rgaa-rules",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.20",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "rgaa-core"
 version = "0.1.0"
 dependencies = [
@@ -1450,16 +1722,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgaa-mcp"
+version = "0.1.0"
+dependencies = [
+ "rgaa-core",
+ "rgaa-obscura",
+ "rgaa-remediation",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "rgaa-obscura"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "futures-util",
  "reqwest",
  "rgaa-core",
  "rgaa-rules",
  "serde",
  "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -1481,6 +1773,16 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "rgaa-remediation"
+version = "0.1.0"
+dependencies = [
+ "rgaa-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1519,6 +1821,42 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f17072af977b0f86f714dbd64b3d37d0715bb63064f9d13483f0a1775813374"
+dependencies = [
+ "base64 0.23.1",
+ "chrono",
+ "futures",
+ "indexmap",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54817231d63a35330d5c3a5782a4a166fbe3b914a9faab440d3dd8bd37971890"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1638,6 +1976,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +2048,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +2092,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1905,7 +2293,7 @@ checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2048,6 +2436,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2261,6 +2655,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,10 +2858,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2490,6 +2910,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -2733,6 +3159,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/rgaa-rs/Cargo.toml
+++ b/rgaa-rs/Cargo.toml
@@ -7,6 +7,10 @@ members = [
     "crates/rgaa-orchestrator",
     "crates/rgaa-storage",
     "crates/rgaa-api",
+    "crates/rgaa-obscura",
+    "crates/rgaa-remediation",
+    "crates/rgaa-mcp",
+    "crates/rgaa-cli",
 ]
 
 [workspace.package]
@@ -19,3 +23,7 @@ serde_json = "1.0"
 anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+rmcp = { version = "3.1.3", features = ["server", "macros", "schemars", "transport-io"] }
+schemars = "1.1"
+clap = { version = "4.0", features = ["derive"] }
+thiserror = "2"

--- a/rgaa-rs/crates/rgaa-core/src/audit_bundle.rs
+++ b/rgaa-rs/crates/rgaa-core/src/audit_bundle.rs
@@ -1,0 +1,286 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{CheckpointResult, CriterionResult, CriterionStatus, Finding, PageError, RgaaError};
+
+pub const CURRENT_SCHEMA_VERSION: &str = "1.0";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AuditConfig {
+    pub max_pages: usize,
+    pub max_depth: u32,
+    pub respect_robots: bool,
+    pub sample_mode: bool,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            max_pages: 50,
+            max_depth: 5,
+            respect_robots: true,
+            sample_mode: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PageAudit {
+    pub page_id: String,
+    pub url: String,
+    pub title: Option<String>,
+    pub criteria: Vec<CriterionResult>,
+    pub findings: Vec<Finding>,
+    pub errors: Vec<PageError>,
+    pub completed: bool,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AuditSummary {
+    pub total_pages: usize,
+    pub completed_pages: usize,
+    pub total_findings: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub needs_review: usize,
+    pub errors: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AuditBundle {
+    pub schema_version: String,
+    pub audit_id: String,
+    pub url: String,
+    pub config: AuditConfig,
+    pub pages: Vec<PageAudit>,
+    pub findings: Vec<Finding>,
+    pub checkpoints: Vec<CheckpointResult>,
+    pub summary: AuditSummary,
+}
+
+impl AuditBundle {
+    pub fn new(audit_id: impl Into<String>, url: impl Into<String>, config: AuditConfig) -> Self {
+        Self {
+            schema_version: CURRENT_SCHEMA_VERSION.to_owned(),
+            audit_id: audit_id.into(),
+            url: url.into(),
+            config,
+            pages: Vec::new(),
+            findings: Vec::new(),
+            checkpoints: Vec::new(),
+            summary: AuditSummary::default(),
+        }
+    }
+
+    /// Validates identifiers, statuses, finding uniqueness, and evidence completeness.
+    pub fn validate(&self) -> Result<(), RgaaError> {
+        if self.audit_id.trim().is_empty() {
+            return Err(RgaaError::MissingId("audit_id".into()));
+        }
+        if self.url.trim().is_empty() {
+            return Err(RgaaError::MissingId("url".into()));
+        }
+        if self.schema_version.trim().is_empty() {
+            return Err(RgaaError::MissingId("schema_version".into()));
+        }
+        if self.schema_version != CURRENT_SCHEMA_VERSION {
+            return Err(RgaaError::UnsupportedSchemaVersion(
+                self.schema_version.clone(),
+            ));
+        }
+
+        for page in &self.pages {
+            if page.page_id.trim().is_empty() {
+                return Err(RgaaError::MissingId("page_id".into()));
+            }
+            if page.url.trim().is_empty() {
+                return Err(RgaaError::MissingId("page.url".into()));
+            }
+            for criterion in &page.criteria {
+                if criterion.criterion_id.trim().is_empty() {
+                    return Err(RgaaError::MissingId("criterion_id".into()));
+                }
+                validate_status(&criterion.status)?;
+            }
+        }
+
+        let mut finding_ids: HashSet<String> = HashSet::with_capacity(
+            self.findings.len()
+                + self
+                    .pages
+                    .iter()
+                    .map(|page| page.findings.len())
+                    .sum::<usize>(),
+        );
+        for finding in &self.findings {
+            validate_finding(finding, &mut finding_ids)?;
+        }
+        for page in &self.pages {
+            for finding in &page.findings {
+                validate_finding(finding, &mut finding_ids)?;
+            }
+        }
+
+        for checkpoint in &self.checkpoints {
+            if checkpoint.checkpoint_id.trim().is_empty() {
+                return Err(RgaaError::MissingId("checkpoint_id".into()));
+            }
+            if checkpoint.criterion_id.trim().is_empty() {
+                return Err(RgaaError::MissingId("criterion_id".into()));
+            }
+            validate_status(&checkpoint.status)?;
+            if checkpoint.status == CriterionStatus::Pass
+                && (checkpoint.evidence.is_empty()
+                    || checkpoint.evidence.iter().any(|evidence| {
+                        evidence.kind.trim().is_empty() || evidence.hash.trim().is_empty()
+                    }))
+            {
+                return Err(RgaaError::IncompleteEvidence(
+                    checkpoint.checkpoint_id.clone(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_status(status: &CriterionStatus) -> Result<(), RgaaError> {
+    match status {
+        CriterionStatus::Pass
+        | CriterionStatus::Fail
+        | CriterionStatus::NotApplicable
+        | CriterionStatus::Error
+        | CriterionStatus::NeedsReview
+        | CriterionStatus::NotTested => Ok(()),
+    }
+}
+
+fn validate_finding(finding: &Finding, finding_ids: &mut HashSet<String>) -> Result<(), RgaaError> {
+    if finding.id.trim().is_empty() {
+        return Err(RgaaError::MissingId("finding.id".into()));
+    }
+    if !finding_ids.insert(finding.id.clone()) {
+        return Err(RgaaError::DuplicateFindingId(finding.id.clone()));
+    }
+    for field in [
+        ("finding.rule", finding.rule.as_str()),
+        ("finding.url", finding.url.as_str()),
+        ("finding.target", finding.target.as_str()),
+    ] {
+        if field.1.trim().is_empty() {
+            return Err(RgaaError::MissingField(field.0.into()));
+        }
+    }
+    validate_status(&finding.status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundle_round_trips_and_defaults_to_schema_one() {
+        let bundle = AuditBundle::new("audit-1", "https://example.test", AuditConfig::default());
+        let json = serde_json::to_string(&bundle).unwrap();
+        let decoded: AuditBundle = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.schema_version, "1.0");
+        assert_eq!(decoded.audit_id, "audit-1");
+    }
+
+    #[test]
+    fn unsupported_schema_versions_are_rejected() {
+        let mut bundle =
+            AuditBundle::new("audit-1", "https://example.test", AuditConfig::default());
+        bundle.schema_version = "2.0".into();
+
+        assert!(matches!(
+            bundle.validate(),
+            Err(RgaaError::UnsupportedSchemaVersion(_))
+        ));
+    }
+
+    #[test]
+    fn duplicate_finding_ids_are_rejected() {
+        let mut bundle =
+            AuditBundle::new("audit-1", "https://example.test", AuditConfig::default());
+        bundle.findings = vec![valid_finding("finding-1"), valid_finding("finding-1")];
+
+        assert!(matches!(
+            bundle.validate(),
+            Err(RgaaError::DuplicateFindingId(_))
+        ));
+    }
+
+    #[test]
+    fn missing_ids_are_rejected() {
+        let bundle = AuditBundle::new("", "https://example.test", AuditConfig::default());
+
+        assert!(matches!(bundle.validate(), Err(RgaaError::MissingId(_))));
+    }
+
+    #[test]
+    fn duplicate_ids_are_rejected_across_page_and_top_level_findings() {
+        let mut bundle =
+            AuditBundle::new("audit-1", "https://example.test", AuditConfig::default());
+        bundle.findings.push(valid_finding("finding-1"));
+        bundle.pages.push(PageAudit {
+            page_id: "page-1".into(),
+            url: "https://example.test/page".into(),
+            title: None,
+            criteria: Vec::new(),
+            findings: vec![valid_finding("finding-1")],
+            errors: Vec::new(),
+            completed: true,
+            duration_ms: 1,
+        });
+
+        assert!(matches!(
+            bundle.validate(),
+            Err(RgaaError::DuplicateFindingId(_))
+        ));
+    }
+
+    #[test]
+    fn duplicate_ids_are_rejected_between_pages() {
+        let mut bundle =
+            AuditBundle::new("audit-1", "https://example.test", AuditConfig::default());
+        for page_id in ["page-1", "page-2"] {
+            bundle.pages.push(PageAudit {
+                page_id: page_id.into(),
+                url: format!("https://example.test/{page_id}"),
+                title: None,
+                criteria: Vec::new(),
+                findings: vec![valid_finding("finding-1")],
+                errors: Vec::new(),
+                completed: true,
+                duration_ms: 1,
+            });
+        }
+
+        assert!(matches!(
+            bundle.validate(),
+            Err(RgaaError::DuplicateFindingId(_))
+        ));
+    }
+
+    #[test]
+    fn findings_require_rule_url_and_target() {
+        let mut bundle =
+            AuditBundle::new("audit-1", "https://example.test", AuditConfig::default());
+        bundle.findings.push(Finding::new("finding-1"));
+
+        assert!(matches!(bundle.validate(), Err(RgaaError::MissingField(_))));
+    }
+
+    fn valid_finding(id: &str) -> Finding {
+        let mut finding = Finding::new(id);
+        finding.rule = "rgaa-1.1".into();
+        finding.url = "https://example.test".into();
+        finding.target = "#main".into();
+        finding
+    }
+}

--- a/rgaa-rs/crates/rgaa-core/src/checkpoints.rs
+++ b/rgaa-rs/crates/rgaa-core/src/checkpoints.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{CriterionStatus, EvidenceRef};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PageError {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CheckpointResult {
+    pub checkpoint_id: String,
+    pub criterion_id: String,
+    pub status: CriterionStatus,
+    pub evidence: Vec<EvidenceRef>,
+    pub summary: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AuditBundle, AuditConfig, RgaaError};
+
+    #[test]
+    fn passing_checkpoint_requires_evidence() {
+        let checkpoint = CheckpointResult {
+            checkpoint_id: "checkpoint-1".into(),
+            criterion_id: "1.1".into(),
+            status: CriterionStatus::Pass,
+            evidence: Vec::new(),
+            summary: "verified".into(),
+        };
+        let mut bundle =
+            AuditBundle::new("audit-1", "https://example.test", AuditConfig::default());
+        bundle.checkpoints.push(checkpoint);
+
+        assert!(matches!(
+            bundle.validate(),
+            Err(RgaaError::IncompleteEvidence(_))
+        ));
+    }
+
+    #[test]
+    fn passing_checkpoint_rejects_malformed_evidence() {
+        for evidence in [
+            EvidenceRef::new("", "sha256:abc"),
+            EvidenceRef::new("screenshot", ""),
+        ] {
+            let checkpoint = CheckpointResult {
+                checkpoint_id: "checkpoint-1".into(),
+                criterion_id: "1.1".into(),
+                status: CriterionStatus::Pass,
+                evidence: vec![evidence],
+                summary: "verified".into(),
+            };
+            let mut bundle =
+                AuditBundle::new("audit-1", "https://example.test", AuditConfig::default());
+            bundle.checkpoints.push(checkpoint);
+
+            assert!(matches!(
+                bundle.validate(),
+                Err(RgaaError::IncompleteEvidence(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn page_errors_are_explicitly_serialized() {
+        let error = PageError {
+            code: "navigation".into(),
+            message: "failed".into(),
+        };
+
+        assert_eq!(serde_json::to_value(error).unwrap()["code"], "navigation");
+    }
+}

--- a/rgaa-rs/crates/rgaa-core/src/error.rs
+++ b/rgaa-rs/crates/rgaa-core/src/error.rs
@@ -16,6 +16,18 @@ pub enum RgaaError {
     Storage(String),
     #[error("Invalid criterion ID: {0}")]
     InvalidCriterion(String),
+    #[error("missing required ID: {0}")]
+    MissingId(String),
+    #[error("missing required field: {0}")]
+    MissingField(String),
+    #[error("unsupported schema version: {0}")]
+    UnsupportedSchemaVersion(String),
+    #[error("duplicate finding ID: {0}")]
+    DuplicateFindingId(String),
+    #[error("invalid status: {0}")]
+    InvalidStatus(String),
+    #[error("incomplete evidence for {0}")]
+    IncompleteEvidence(String),
     #[error("Timeout after {0}ms")]
     Timeout(u64),
 }

--- a/rgaa-rs/crates/rgaa-core/src/evidence.rs
+++ b/rgaa-rs/crates/rgaa-core/src/evidence.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvidenceRef {
+    pub kind: String,
+    pub hash: String,
+    pub location: Option<String>,
+}
+
+impl EvidenceRef {
+    pub fn new(kind: impl Into<String>, hash: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            hash: hash.into(),
+            location: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evidence_reference_preserves_kind_and_hash() {
+        let evidence = EvidenceRef::new("dom_snapshot", "sha256:abc");
+        let json = serde_json::to_string(&evidence).unwrap();
+        let decoded: EvidenceRef = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded, evidence);
+    }
+}

--- a/rgaa-rs/crates/rgaa-core/src/findings.rs
+++ b/rgaa-rs/crates/rgaa-core/src/findings.rs
@@ -1,0 +1,137 @@
+use serde::{Deserialize, Serialize};
+
+use crate::EvidenceRef;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Finding {
+    pub id: String,
+    pub rule: String,
+    pub criterion_id: Option<String>,
+    pub url: String,
+    pub target: String,
+    pub component_path: Option<String>,
+    pub evidence: Vec<EvidenceRef>,
+    pub status: crate::CriterionStatus,
+    pub severity: Option<String>,
+    pub description: Option<String>,
+    pub remediation: Option<String>,
+    #[serde(default)]
+    pub html: Option<String>,
+    #[serde(default)]
+    pub details: Option<String>,
+    #[serde(default)]
+    pub source: String,
+}
+
+impl Finding {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            rule: String::new(),
+            criterion_id: None,
+            url: String::new(),
+            target: String::new(),
+            component_path: None,
+            evidence: Vec::new(),
+            status: crate::CriterionStatus::NotTested,
+            severity: None,
+            description: None,
+            remediation: None,
+            html: None,
+            details: None,
+            source: String::new(),
+        }
+    }
+}
+
+/// Stable persisted fingerprint format: `rgaa-fp-v1-` followed by a 16-digit
+/// lowercase hexadecimal FNV-1a hash of length-prefixed UTF-8 fields.
+pub struct FindingFingerprint;
+
+impl FindingFingerprint {
+    pub fn from_finding(finding: &Finding) -> String {
+        let mut hash = 0xcbf29ce484222325_u64;
+        hash = hash_field(hash, Some(&finding.rule));
+        hash = hash_field(hash, Some(&finding.url));
+        hash = hash_field(hash, Some(&finding.target));
+        hash = hash_field(hash, finding.component_path.as_deref());
+        hash = hash_field(hash, Some(&finding.evidence.len().to_string()));
+        for evidence in &finding.evidence {
+            hash = hash_field(hash, Some(&evidence.kind));
+            hash = hash_field(hash, Some(&evidence.hash));
+            hash = hash_field(hash, evidence.location.as_deref());
+        }
+        format!("rgaa-fp-v1-{hash:016x}")
+    }
+}
+
+fn hash_field(mut hash: u64, field: Option<&str>) -> u64 {
+    match field {
+        None => fnv_byte(hash, 0),
+        Some(value) => {
+            hash = fnv_byte(hash, 1);
+            for byte in (value.len() as u64).to_le_bytes() {
+                hash = fnv_byte(hash, byte);
+            }
+            for &byte in value.as_bytes() {
+                hash = fnv_byte(hash, byte);
+            }
+            hash
+        }
+    }
+}
+
+fn fnv_byte(hash: u64, byte: u8) -> u64 {
+    (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_findings_have_identical_fingerprints() {
+        let mut left = Finding::new("finding-1");
+        left.rule = "rgaa-1.1".into();
+        left.url = "https://example.test".into();
+        left.target = "#main".into();
+        left.component_path = Some("App > Main".into());
+        left.evidence = vec![EvidenceRef::new("screenshot", "sha256:abc")];
+        let right = left.clone();
+
+        assert_eq!(
+            FindingFingerprint::from_finding(&left),
+            FindingFingerprint::from_finding(&right)
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_evidence_location_changes() {
+        let mut finding = valid_finding();
+        finding.evidence = vec![EvidenceRef {
+            kind: "screenshot".into(),
+            hash: "sha256:abc".into(),
+            location: Some("before.png".into()),
+        }];
+        let first = FindingFingerprint::from_finding(&finding);
+        finding.evidence[0].location = Some("after.png".into());
+
+        assert_ne!(first, FindingFingerprint::from_finding(&finding));
+    }
+
+    #[test]
+    fn fingerprint_uses_stable_persistence_format() {
+        let fingerprint = FindingFingerprint::from_finding(&valid_finding());
+
+        assert!(fingerprint.starts_with("rgaa-fp-v1-"));
+        assert_eq!(fingerprint.len(), 27);
+    }
+
+    fn valid_finding() -> Finding {
+        let mut finding = Finding::new("finding-1");
+        finding.rule = "rgaa-1.1".into();
+        finding.url = "https://example.test".into();
+        finding.target = "#main".into();
+        finding
+    }
+}

--- a/rgaa-rs/crates/rgaa-core/src/lib.rs
+++ b/rgaa-rs/crates/rgaa-core/src/lib.rs
@@ -1,7 +1,15 @@
+pub mod audit_bundle;
+pub mod checkpoints;
 pub mod criteria;
-pub mod types;
 pub mod error;
+pub mod evidence;
+pub mod findings;
+pub mod types;
 
-pub use criteria::{RgaaCriteria, Criterion};
+pub use audit_bundle::*;
+pub use checkpoints::*;
+pub use criteria::{Criterion, RgaaCriteria};
+pub use error::{Result, RgaaError};
+pub use evidence::*;
+pub use findings::*;
 pub use types::*;
-pub use error::{RgaaError, Result};

--- a/rgaa-rs/crates/rgaa-core/src/types.rs
+++ b/rgaa-rs/crates/rgaa-core/src/types.rs
@@ -8,14 +8,17 @@ pub enum Classification {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum CriterionStatus {
     Pass,
     Fail,
-    Na,
+    NotApplicable,
     Error,
+    NeedsReview,
+    NotTested,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CriterionResult {
     pub criterion_id: String,
     pub title: String,
@@ -27,7 +30,7 @@ pub struct CriterionResult {
     pub source: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Violation {
     pub rule_id: String,
     pub impact: String,
@@ -35,7 +38,7 @@ pub struct Violation {
     pub nodes_affected: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PageResult {
     pub url: String,
     pub title: Option<String>,
@@ -44,7 +47,7 @@ pub struct PageResult {
     pub crawl_depth: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AuditResult {
     pub audit_id: String,
     pub url: String,
@@ -73,5 +76,31 @@ impl Default for CrawlConfig {
             respect_robots: true,
             sample_mode: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn criterion_statuses_have_stable_json_names() {
+        let statuses = [
+            (CriterionStatus::Pass, "pass"),
+            (CriterionStatus::Fail, "fail"),
+            (CriterionStatus::NotApplicable, "not_applicable"),
+            (CriterionStatus::Error, "error"),
+            (CriterionStatus::NeedsReview, "needs_review"),
+            (CriterionStatus::NotTested, "not_tested"),
+        ];
+
+        for (status, expected) in statuses {
+            assert_eq!(
+                serde_json::to_string(&status).unwrap(),
+                format!("\"{expected}\"")
+            );
+        }
+
+        assert!(serde_json::from_str::<CriterionStatus>("\"na\"").is_err());
     }
 }

--- a/rgaa-rs/crates/rgaa-obscura/Cargo.toml
+++ b/rgaa-rs/crates/rgaa-obscura/Cargo.toml
@@ -11,6 +11,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
+thiserror = "1.0"
+base64 = "0.22"
+sha2 = "0.10"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"

--- a/rgaa-rs/crates/rgaa-obscura/src/config.rs
+++ b/rgaa-rs/crates/rgaa-obscura/src/config.rs
@@ -1,0 +1,294 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ObscuraError;
+
+const MAX_SELECTOR_LENGTH: usize = 1024;
+const MAX_PRE_SCAN_ACTIONS: usize = 20;
+const MIN_VIEWPORT_WIDTH: u32 = 320;
+const MAX_VIEWPORT_WIDTH: u32 = 7680;
+const MIN_VIEWPORT_HEIGHT: u32 = 240;
+const MAX_VIEWPORT_HEIGHT: u32 = 4320;
+const MIN_TIMEOUT_MS: u64 = 100;
+const MAX_TIMEOUT_MS: u64 = 300_000;
+const MAX_RETRY_LIMIT: u8 = 5;
+const MAX_CONCURRENCY: usize = 32;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Viewport {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PreScanAction {
+    Click { selector: String },
+    Fill { selector: String, value: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CookieReference {
+    pub name: String,
+    pub domain: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ScreenshotPolicy {
+    #[default]
+    None,
+    OnFailure,
+    Always,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AdvancedRulePolicy {
+    #[default]
+    Disabled,
+    Enabled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum NeedsReviewPolicy {
+    #[default]
+    Record,
+    Fail,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AnalyzeConfig {
+    pub profile: String,
+    pub viewport: Viewport,
+    pub selector: Option<String>,
+    pub pre_scan_actions: Vec<PreScanAction>,
+    pub cookie_references: Vec<CookieReference>,
+    pub screenshot_policy: ScreenshotPolicy,
+    pub advanced_rule_policy: AdvancedRulePolicy,
+    pub needs_review_policy: NeedsReviewPolicy,
+    pub timeout_ms: u64,
+    pub retry_limit: u8,
+    pub concurrency: usize,
+}
+
+impl Default for AnalyzeConfig {
+    fn default() -> Self {
+        Self {
+            profile: "default".into(),
+            viewport: Viewport {
+                width: 1000,
+                height: 1080,
+            },
+            selector: None,
+            pre_scan_actions: Vec::new(),
+            cookie_references: Vec::new(),
+            screenshot_policy: ScreenshotPolicy::None,
+            advanced_rule_policy: AdvancedRulePolicy::Disabled,
+            needs_review_policy: NeedsReviewPolicy::Record,
+            timeout_ms: 30_000,
+            retry_limit: 0,
+            concurrency: 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AnalyzeRequest {
+    pub url: String,
+    pub config: AnalyzeConfig,
+}
+
+impl AnalyzeRequest {
+    pub fn validate(&self) -> Result<(), ObscuraError> {
+        let parsed = reqwest::Url::parse(&self.url)
+            .map_err(|_| ObscuraError::Validation("url must be an absolute URL".into()))?;
+        if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+            return Err(ObscuraError::Validation(
+                "url must use http or https and include a host".into(),
+            ));
+        }
+
+        let viewport = &self.config.viewport;
+        if !(MIN_VIEWPORT_WIDTH..=MAX_VIEWPORT_WIDTH).contains(&viewport.width)
+            || !(MIN_VIEWPORT_HEIGHT..=MAX_VIEWPORT_HEIGHT).contains(&viewport.height)
+        {
+            return Err(ObscuraError::Validation(
+                "viewport dimensions are outside the supported range".into(),
+            ));
+        }
+        if let Some(selector) = &self.config.selector {
+            if selector.trim().is_empty() || selector.len() > MAX_SELECTOR_LENGTH {
+                return Err(ObscuraError::Validation(
+                    "selector must be non-empty and at most 1024 bytes".into(),
+                ));
+            }
+        }
+        if self.config.pre_scan_actions.len() > MAX_PRE_SCAN_ACTIONS {
+            return Err(ObscuraError::Validation(
+                "pre-scan action count exceeds the limit of 20".into(),
+            ));
+        }
+        for action in &self.config.pre_scan_actions {
+            let (selector, value) = match action {
+                PreScanAction::Click { selector } => (selector, None),
+                PreScanAction::Fill { selector, value } => (selector, Some(value)),
+            };
+            if selector.trim().is_empty() || selector.len() > MAX_SELECTOR_LENGTH {
+                return Err(ObscuraError::Validation(
+                    "pre-scan action selector is invalid".into(),
+                ));
+            }
+            if value.is_some_and(|value| value.len() > MAX_SELECTOR_LENGTH) {
+                return Err(ObscuraError::Validation(
+                    "pre-scan fill value is too long".into(),
+                ));
+            }
+        }
+        if !(MIN_TIMEOUT_MS..=MAX_TIMEOUT_MS).contains(&self.config.timeout_ms) {
+            return Err(ObscuraError::Validation(
+                "timeout must be between 100 and 300000 milliseconds".into(),
+            ));
+        }
+        if self.config.retry_limit > MAX_RETRY_LIMIT {
+            return Err(ObscuraError::Validation("retry limit exceeds 5".into()));
+        }
+        if !(1..=MAX_CONCURRENCY).contains(&self.config.concurrency) {
+            return Err(ObscuraError::Validation(
+                "concurrency must be between 1 and 32".into(),
+            ));
+        }
+        for cookie in &self.config.cookie_references {
+            if cookie.name.trim().is_empty() {
+                return Err(ObscuraError::Validation(
+                    "cookie reference name must not be empty".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn validate_supported(&self) -> Result<(), ObscuraError> {
+        self.validate()?;
+        if !matches!(
+            self.config.profile.as_str(),
+            "default" | "desktop" | "mobile"
+        ) {
+            return Err(ObscuraError::UnsupportedConfiguration(format!(
+                "unknown profile '{}'",
+                self.config.profile
+            )));
+        }
+        if self.config.concurrency != 1 {
+            return Err(ObscuraError::UnsupportedConfiguration(
+                "analyze handles one page; concurrency greater than 1 requires a batch API".into(),
+            ));
+        }
+        if self.config.advanced_rule_policy == AdvancedRulePolicy::Enabled {
+            return Err(ObscuraError::UnsupportedConfiguration(
+                "advanced rules are not available in the local axe runner".into(),
+            ));
+        }
+        if self.config.needs_review_policy == NeedsReviewPolicy::Fail {
+            return Err(ObscuraError::PolicyDenied(
+                "needs-review fail policy requires a manual-review sink not provided by analyze"
+                    .into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_desktop_viewport() {
+        assert_eq!(
+            AnalyzeConfig::default().viewport,
+            Viewport {
+                width: 1000,
+                height: 1080
+            }
+        );
+    }
+
+    #[test]
+    fn accepts_mobile_viewport_override() {
+        let config = AnalyzeConfig {
+            viewport: Viewport {
+                width: 375,
+                height: 812,
+            },
+            ..Default::default()
+        };
+        assert!(AnalyzeRequest {
+            url: "https://example.test".into(),
+            config
+        }
+        .validate()
+        .is_ok());
+    }
+
+    #[test]
+    fn rejects_malformed_inputs_and_unbounded_actions() {
+        let mut request = AnalyzeRequest {
+            url: "not-a-url".into(),
+            config: AnalyzeConfig::default(),
+        };
+        assert!(request.validate().is_err());
+        request.url = "https://example.test".into();
+        request.config.selector = Some(" ".into());
+        assert!(request.validate().is_err());
+        request.config.selector = None;
+        request.config.pre_scan_actions = (0..21)
+            .map(|_| PreScanAction::Click {
+                selector: "#ok".into(),
+            })
+            .collect();
+        assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn cookie_serialization_contains_references_only() {
+        let config = AnalyzeConfig {
+            cookie_references: vec![CookieReference {
+                name: "session".into(),
+                domain: Some("example.test".into()),
+            }],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&config).expect("config serializes");
+        assert!(json.contains("session"));
+        assert!(!json.contains("value"));
+    }
+
+    #[test]
+    fn screenshot_is_opt_in() {
+        assert_eq!(
+            AnalyzeConfig::default().screenshot_policy,
+            ScreenshotPolicy::None
+        );
+    }
+
+    #[test]
+    fn rejects_configuration_that_analyze_cannot_execute() {
+        let mut request = AnalyzeRequest {
+            url: "https://example.test".into(),
+            config: AnalyzeConfig::default(),
+        };
+        request.config.advanced_rule_policy = AdvancedRulePolicy::Enabled;
+        assert!(matches!(
+            request.validate_supported(),
+            Err(ObscuraError::UnsupportedConfiguration(_))
+        ));
+
+        request.config.advanced_rule_policy = AdvancedRulePolicy::Disabled;
+        request.config.concurrency = 2;
+        assert!(matches!(
+            request.validate_supported(),
+            Err(ObscuraError::UnsupportedConfiguration(_))
+        ));
+    }
+}

--- a/rgaa-rs/crates/rgaa-obscura/src/evidence.rs
+++ b/rgaa-rs/crates/rgaa-obscura/src/evidence.rs
@@ -1,0 +1,101 @@
+use crate::ObscuraError;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvidenceArtifact {
+    pub kind: String,
+    pub bytes: Vec<u8>,
+}
+
+impl EvidenceArtifact {
+    pub fn new(kind: impl Into<String>, bytes: Vec<u8>) -> Self {
+        Self {
+            kind: kind.into(),
+            bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvidenceRef {
+    pub kind: String,
+    pub path: String,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvidenceStore {
+    root: PathBuf,
+}
+
+impl EvidenceStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn write(&self, evidence: EvidenceArtifact) -> Result<EvidenceRef, ObscuraError> {
+        fs::create_dir_all(&self.root).map_err(|error| {
+            ObscuraError::Evidence(format!("failed to create evidence directory: {error}"))
+        })?;
+        let digest = Sha256::digest(&evidence.bytes);
+        let hash = format!("sha256:{digest:x}");
+        if evidence.kind == "screenshot"
+            && !evidence
+                .bytes
+                .starts_with(&[137, 80, 78, 71, 13, 10, 26, 10])
+        {
+            return Err(ObscuraError::Evidence(
+                "screenshot evidence is not a PNG image".into(),
+            ));
+        }
+        let extension = match evidence.kind.as_str() {
+            "screenshot" => "png",
+            "tree" | "state" => "json",
+            _ => "bin",
+        };
+        let destination = self.root.join(format!("{digest:x}.{extension}"));
+        if !destination.exists() {
+            let temporary = self
+                .root
+                .join(format!(".{digest:x}.{}.tmp", uuid::Uuid::new_v4()));
+            let mut file = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&temporary)
+                .map_err(|error| {
+                    ObscuraError::Evidence(format!("failed to create evidence file: {error}"))
+                })?;
+            if let Err(error) = write_and_sync(&mut file, &evidence.bytes) {
+                let _ = fs::remove_file(&temporary);
+                return Err(ObscuraError::Evidence(format!(
+                    "failed to write evidence: {error}"
+                )));
+            }
+            if let Err(error) = fs::rename(&temporary, &destination) {
+                let _ = fs::remove_file(&temporary);
+                return Err(ObscuraError::Evidence(format!(
+                    "failed to commit evidence: {error}"
+                )));
+            }
+            if let Err(error) = File::open(&self.root).and_then(|directory| directory.sync_all()) {
+                return Err(ObscuraError::Evidence(format!(
+                    "failed to sync evidence directory: {error}"
+                )));
+            }
+        }
+        Ok(EvidenceRef {
+            kind: evidence.kind,
+            path: destination.to_string_lossy().into_owned(),
+            sha256: hash,
+        })
+    }
+}
+
+fn write_and_sync(file: &mut File, bytes: &[u8]) -> std::io::Result<()> {
+    file.write_all(bytes)?;
+    file.sync_all()
+}

--- a/rgaa-rs/crates/rgaa-obscura/src/guided.rs
+++ b/rgaa-rs/crates/rgaa-obscura/src/guided.rs
@@ -1,0 +1,602 @@
+use crate::evidence::{EvidenceArtifact, EvidenceRef, EvidenceStore};
+use crate::ObscuraError;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tokio::net::TcpStream;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+const MAX_STEP_ATTEMPTS: usize = 3;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GuidedTest {
+    pub id: String,
+    pub version: u32,
+    #[serde(default)]
+    pub preconditions: Vec<String>,
+    pub steps: Vec<GuidedStep>,
+    #[serde(default)]
+    pub criterion_mapping: Vec<String>,
+    #[serde(default)]
+    pub evidence_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GuidedStep {
+    Navigate { url: String },
+    AccessibilityTree,
+    PressKey { key: String },
+    ClickRef { reference: String },
+    FillRef { reference: String, value: String },
+    Screenshot,
+    AssertState { expected: serde_json::Value },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GuidedAction {
+    Navigate { url: String },
+    AccessibilityTree,
+    PressKey { key: String },
+    ClickRef { reference: String },
+    FillRef { reference: String, value: String },
+    Screenshot,
+    AssertState { expected: serde_json::Value },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GuidedObservation {
+    #[serde(default)]
+    pub tree_refs: Vec<String>,
+    #[serde(default)]
+    pub state: Option<serde_json::Value>,
+    #[serde(default)]
+    pub evidence: Vec<EvidenceArtifact>,
+}
+
+impl GuidedObservation {
+    pub fn tree(refs: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            tree_refs: refs.into_iter().map(Into::into).collect(),
+            ..Default::default()
+        }
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait GuidedExecutor {
+    async fn execute(&mut self, action: &GuidedAction) -> Result<GuidedObservation, ObscuraError>;
+}
+
+pub fn is_stable_accessibility_reference(reference: &str) -> bool {
+    reference
+        .strip_prefix("ax:")
+        .is_some_and(|value| value.parse::<u64>().is_ok())
+        || (reference.starts_with("ax-role=") && reference.contains(";name="))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum TerminationReason {
+    Completed,
+    MissingReference,
+    AssertionFailed,
+    KeyboardTrap,
+    Timeout,
+    NavigationError,
+    #[default]
+    ExecutionError,
+    InvalidOrdering,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GuidedRunResult {
+    pub issues: Vec<String>,
+    pub unanalyzed_elements: Vec<String>,
+    pub terminated_reason: TerminationReason,
+    pub completed_steps: usize,
+    pub evidence: Vec<EvidenceRef>,
+    pub manual_review_required: bool,
+    pub action_trace: Vec<GuidedAction>,
+    pub criterion_mapping: Vec<String>,
+    #[serde(default)]
+    pub evidence_requirements: Vec<String>,
+}
+
+fn state_matches(expected: &serde_json::Value, actual: &serde_json::Value) -> bool {
+    match (expected, actual) {
+        (serde_json::Value::Object(expected), serde_json::Value::Object(actual)) => {
+            expected.iter().all(|(key, value)| {
+                actual
+                    .get(key)
+                    .is_some_and(|candidate| state_matches(value, candidate))
+            })
+        }
+        (serde_json::Value::Array(expected), serde_json::Value::Array(actual)) => {
+            expected.len() == actual.len()
+                && expected
+                    .iter()
+                    .zip(actual)
+                    .all(|(expected, actual)| state_matches(expected, actual))
+        }
+        _ => expected == actual,
+    }
+}
+
+impl GuidedRunResult {
+    pub fn is_pass(&self) -> bool {
+        self.terminated_reason == TerminationReason::Completed
+            && self.issues.is_empty()
+            && self.unanalyzed_elements.is_empty()
+            && !self.manual_review_required
+            && self.evidence_requirements.iter().all(|required| {
+                self.evidence
+                    .iter()
+                    .any(|evidence| evidence.kind == *required)
+            })
+    }
+}
+
+impl GuidedTest {
+    pub async fn run<E: GuidedExecutor>(
+        &self,
+        executor: &mut E,
+        evidence_store: Option<&EvidenceStore>,
+    ) -> Result<GuidedRunResult, ObscuraError> {
+        let mut result = GuidedRunResult {
+            criterion_mapping: self.criterion_mapping.clone(),
+            evidence_requirements: self.evidence_requirements.clone(),
+            ..Default::default()
+        };
+        let mut index = 0;
+        while index < self.steps.len() {
+            let step = &self.steps[index];
+            if is_mutating(step)
+                && !self
+                    .steps
+                    .get(index + 1)
+                    .is_some_and(is_observation_or_assertion)
+            {
+                result.terminated_reason = TerminationReason::InvalidOrdering;
+                result
+                    .issues
+                    .push("mutating action must be followed by observation or assertion".into());
+                result.manual_review_required = true;
+                mark_unanalyzed(&mut result, &self.steps[index..]);
+                break;
+            }
+            let action: GuidedAction = step.clone().into();
+            result.action_trace.push(action.clone());
+            match execute_bounded(executor, &action).await {
+                Ok(observation) => {
+                    result.completed_steps += 1;
+                    if !observation.tree_refs.is_empty() {
+                        let bytes = serde_json::to_vec(&observation.tree_refs)
+                            .map_err(|error| ObscuraError::Json(error.to_string()))?;
+                        if let Some(store) = evidence_store {
+                            result
+                                .evidence
+                                .push(store.write(EvidenceArtifact::new("tree", bytes))?);
+                        }
+                    }
+                    for artifact in observation.evidence {
+                        if let Some(store) = evidence_store {
+                            result.evidence.push(store.write(artifact)?);
+                        }
+                    }
+                    if let GuidedStep::AssertState { expected } = step {
+                        if !observation
+                            .state
+                            .as_ref()
+                            .is_some_and(|actual| state_matches(expected, actual))
+                        {
+                            result.terminated_reason = TerminationReason::AssertionFailed;
+                            result.issues.push("assertion failed".into());
+                            result.manual_review_required = true;
+                            mark_unanalyzed(&mut result, &self.steps[index + 1..]);
+                            break;
+                        }
+                    }
+                }
+                Err(error) => {
+                    result.terminated_reason = reason_for(&error);
+                    result.issues.push(error.to_string());
+                    mark_unanalyzed(&mut result, &self.steps[index..]);
+                    result.manual_review_required = true;
+                    break;
+                }
+            }
+            index += 1;
+        }
+        if result.completed_steps == self.steps.len()
+            && result.terminated_reason == TerminationReason::ExecutionError
+        {
+            result.terminated_reason = TerminationReason::Completed;
+        }
+        for required in &result.evidence_requirements {
+            if !result
+                .evidence
+                .iter()
+                .any(|evidence| evidence.kind == *required)
+            {
+                result
+                    .issues
+                    .push(format!("required evidence is missing: {required}"));
+                result
+                    .unanalyzed_elements
+                    .push(format!("evidence:{required}"));
+                result.manual_review_required = true;
+            }
+        }
+        Ok(result)
+    }
+}
+
+async fn execute_bounded<E: GuidedExecutor>(
+    executor: &mut E,
+    action: &GuidedAction,
+) -> Result<GuidedObservation, ObscuraError> {
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        match executor.execute(action).await {
+            Ok(observation) => return Ok(observation),
+            Err(error) if attempts < MAX_STEP_ATTEMPTS && is_retryable(&error) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn is_retryable(error: &ObscuraError) -> bool {
+    matches!(
+        error,
+        ObscuraError::Timeout(_) | ObscuraError::CdpTransport(_)
+    )
+}
+
+impl From<GuidedStep> for GuidedAction {
+    fn from(step: GuidedStep) -> Self {
+        match step {
+            GuidedStep::Navigate { url } => Self::Navigate { url },
+            GuidedStep::AccessibilityTree => Self::AccessibilityTree,
+            GuidedStep::PressKey { key } => Self::PressKey { key },
+            GuidedStep::ClickRef { reference } => Self::ClickRef { reference },
+            GuidedStep::FillRef { reference, value } => Self::FillRef { reference, value },
+            GuidedStep::Screenshot => Self::Screenshot,
+            GuidedStep::AssertState { expected } => Self::AssertState { expected },
+        }
+    }
+}
+
+fn is_mutating(step: &GuidedStep) -> bool {
+    matches!(
+        step,
+        GuidedStep::Navigate { .. }
+            | GuidedStep::PressKey { .. }
+            | GuidedStep::ClickRef { .. }
+            | GuidedStep::FillRef { .. }
+    )
+}
+
+fn is_observation_or_assertion(step: &GuidedStep) -> bool {
+    matches!(
+        step,
+        GuidedStep::AccessibilityTree | GuidedStep::Screenshot | GuidedStep::AssertState { .. }
+    )
+}
+
+fn mark_unanalyzed(result: &mut GuidedRunResult, steps: &[GuidedStep]) {
+    for step in steps {
+        let target = match step {
+            GuidedStep::Navigate { url } => format!("navigate:{url}"),
+            GuidedStep::AccessibilityTree => "accessibility-tree".into(),
+            GuidedStep::PressKey { key } => format!("key:{key}"),
+            GuidedStep::ClickRef { reference } | GuidedStep::FillRef { reference, .. } => {
+                reference.clone()
+            }
+            GuidedStep::Screenshot => "screenshot".into(),
+            GuidedStep::AssertState { .. } => "assert-state".into(),
+        };
+        if !result.unanalyzed_elements.contains(&target) {
+            result.unanalyzed_elements.push(target);
+        }
+    }
+}
+
+fn reason_for(error: &ObscuraError) -> TerminationReason {
+    let message = error.to_string().to_ascii_lowercase();
+    if matches!(error, ObscuraError::Timeout(_)) {
+        TerminationReason::Timeout
+    } else if message.contains("keyboard trap") {
+        TerminationReason::KeyboardTrap
+    } else if message.contains("missing element reference") {
+        TerminationReason::MissingReference
+    } else if matches!(error, ObscuraError::Navigation(_)) {
+        TerminationReason::NavigationError
+    } else if message.contains("assertion") {
+        TerminationReason::AssertionFailed
+    } else {
+        TerminationReason::ExecutionError
+    }
+}
+
+pub(crate) struct ObscuraGuidedExecutor {
+    ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    target_id: String,
+    session_id: String,
+    current_url: Option<String>,
+    accessibility_refs: HashMap<String, u64>,
+}
+
+impl ObscuraGuidedExecutor {
+    pub(crate) async fn connect(bridge: &crate::ObscuraBridge) -> Result<Self, ObscuraError> {
+        let ws_url = bridge
+            .get_browser_ws_url()
+            .await
+            .map_err(crate::ObscuraBridge::classify_error)?;
+        let (mut ws, _) = tokio_tungstenite::connect_async(ws_url)
+            .await
+            .map_err(|error| ObscuraError::CdpTransport(error.to_string()))?;
+        let target = crate::ObscuraBridge::cdp_send(
+            &mut ws,
+            "Target.createTarget",
+            serde_json::json!({"url": "about:blank"}),
+        )
+        .await
+        .map_err(crate::ObscuraBridge::classify_error)?;
+        let target_id = target
+            .get("targetId")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| ObscuraError::CdpTransport("guided target id is missing".into()))?
+            .to_owned();
+        let session = crate::ObscuraBridge::cdp_send(
+            &mut ws,
+            "Target.attachToTarget",
+            serde_json::json!({"targetId": target_id, "flatten": true}),
+        )
+        .await;
+        let session_id = match session {
+            Ok(value) => value
+                .get("sessionId")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| ObscuraError::CdpTransport("guided session id is missing".into()))?,
+            Err(error) => {
+                let _ = crate::ObscuraBridge::cdp_send(
+                    &mut ws,
+                    "Target.closeTarget",
+                    serde_json::json!({"targetId": target_id}),
+                )
+                .await;
+                return Err(crate::ObscuraBridge::classify_error(error));
+            }
+        };
+        Ok(Self {
+            ws,
+            target_id,
+            session_id,
+            current_url: None,
+            accessibility_refs: HashMap::new(),
+        })
+    }
+
+    pub(crate) async fn close(&mut self) -> Result<(), ObscuraError> {
+        crate::ObscuraBridge::cleanup_target(&mut self.ws, &self.session_id, &self.target_id)
+            .await
+            .map_err(crate::ObscuraBridge::classify_error)
+    }
+
+    async fn send(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ObscuraError> {
+        crate::ObscuraBridge::cdp_send_session(&mut self.ws, &self.session_id, method, params)
+            .await
+            .map_err(crate::ObscuraBridge::classify_error)
+    }
+
+    async fn observe_state(&mut self) -> Result<serde_json::Value, ObscuraError> {
+        let result = self
+            .send(
+                "Runtime.evaluate",
+                serde_json::json!({
+                    "expression": "JSON.stringify({url: location.href, title: document.title, active_tag: document.activeElement && document.activeElement.tagName, values: Array.from(document.querySelectorAll('input,textarea,select')).map(e => ({name:e.name, id:e.id, value:e.value}))})",
+                    "returnByValue": true
+                }),
+            )
+            .await?;
+        let value = result
+            .get("result")
+            .and_then(|value| value.get("value"))
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| ObscuraError::Evaluation("browser state was not returned".into()))?;
+        serde_json::from_str(value).map_err(|error| ObscuraError::Json(error.to_string()))
+    }
+
+    async fn active_element_signature(&mut self) -> Result<Option<String>, ObscuraError> {
+        let result = self
+            .send(
+                "Runtime.evaluate",
+                serde_json::json!({
+                    "expression": "document.activeElement ? document.activeElement.outerHTML : null",
+                    "returnByValue": true
+                }),
+            )
+            .await?;
+        Ok(result
+            .get("result")
+            .and_then(|value| value.get("value"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned))
+    }
+
+    async fn resolve_reference(&mut self, reference: &str) -> Result<String, ObscuraError> {
+        let backend_node_id = reference
+            .strip_prefix("ax:")
+            .and_then(|value| value.parse::<u64>().ok())
+            .or_else(|| self.accessibility_refs.get(reference).copied())
+            .filter(|_| is_stable_accessibility_reference(reference))
+            .ok_or_else(|| {
+                ObscuraError::Evaluation(format!(
+                    "missing element reference: {reference} (expected stable ax:<backendNodeId>)"
+                ))
+            })?;
+        let result = self
+            .send(
+                "DOM.resolveNode",
+                serde_json::json!({"backendNodeId": backend_node_id}),
+            )
+            .await?;
+        result
+            .get("object")
+            .and_then(|object| object.get("objectId"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| {
+                ObscuraError::Evaluation(format!("missing element reference: {reference}"))
+            })
+    }
+
+    async fn click_or_fill(
+        &mut self,
+        reference: &str,
+        value: Option<&str>,
+    ) -> Result<(), ObscuraError> {
+        let object_id = self.resolve_reference(reference).await?;
+        let function = if value.is_some() {
+            "function(value) { this.focus(); this.value = value; this.dispatchEvent(new Event('input', {bubbles:true})); this.dispatchEvent(new Event('change', {bubbles:true})); return true; }"
+        } else {
+            "function() { this.click(); return true; }"
+        };
+        let mut params = serde_json::json!({
+            "objectId": object_id,
+            "functionDeclaration": function,
+            "returnByValue": true
+        });
+        if let Some(value) = value {
+            params["arguments"] = serde_json::json!([{"value": value}]);
+        }
+        let response = self.send("Runtime.callFunctionOn", params).await?;
+        if response.get("exceptionDetails").is_some() {
+            return Err(ObscuraError::Evaluation(format!(
+                "failed to operate on element reference: {reference}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl GuidedExecutor for ObscuraGuidedExecutor {
+    async fn execute(&mut self, action: &GuidedAction) -> Result<GuidedObservation, ObscuraError> {
+        if !matches!(action, GuidedAction::Navigate { .. }) && self.current_url.is_none() {
+            return Err(ObscuraError::Navigation(
+                "guided test has no current URL".into(),
+            ));
+        }
+        match action {
+            GuidedAction::Navigate { url } => {
+                let result = self
+                    .send("Page.navigate", serde_json::json!({"url": url}))
+                    .await?;
+                if result.get("errorText").is_some() {
+                    return Err(ObscuraError::Navigation(result["errorText"].to_string()));
+                }
+                crate::ObscuraBridge::wait_for_load(
+                    &mut self.ws,
+                    &self.session_id,
+                    std::time::Duration::from_secs(30),
+                )
+                .await
+                .map_err(crate::ObscuraBridge::classify_error)?;
+                self.current_url = Some(url.clone());
+                Ok(GuidedObservation::default())
+            }
+            GuidedAction::AccessibilityTree => {
+                self.send("Accessibility.enable", serde_json::json!({}))
+                    .await?;
+                let value = self
+                    .send("Accessibility.getFullAXTree", serde_json::json!({}))
+                    .await?;
+                let refs = value
+                    .get("nodes")
+                    .and_then(serde_json::Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|node| {
+                        let backend_id = node.get("backendDOMNodeId")?.as_u64()?;
+                        let role = node.get("role")?.get("value")?.as_str()?;
+                        let name = node.get("name")?.get("value")?.as_str()?;
+                        if !role.is_empty() && !name.is_empty() {
+                            self.accessibility_refs
+                                .insert(format!("ax-role={role};name={name}"), backend_id);
+                        }
+                        Some(format!("ax:{backend_id}"))
+                    });
+                let tree_refs = refs.collect::<Vec<_>>();
+                let evidence = serde_json::to_vec(&value)
+                    .map_err(|error| ObscuraError::Json(error.to_string()))?;
+                Ok(GuidedObservation {
+                    tree_refs,
+                    evidence: vec![EvidenceArtifact::new("tree", evidence)],
+                    ..Default::default()
+                })
+            }
+            GuidedAction::PressKey { key } => {
+                let before = self.active_element_signature().await?;
+                self.send(
+                    "Input.dispatchKeyEvent",
+                    serde_json::json!({"type":"keyDown", "key":key}),
+                )
+                .await?;
+                self.send(
+                    "Input.dispatchKeyEvent",
+                    serde_json::json!({"type":"keyUp", "key":key}),
+                )
+                .await?;
+                let after = self.active_element_signature().await?;
+                if key == "Tab" && before.is_some() && before == after {
+                    return Err(ObscuraError::Evaluation("keyboard trap detected".into()));
+                }
+                Ok(GuidedObservation::default())
+            }
+            GuidedAction::ClickRef { reference } => {
+                self.click_or_fill(reference, None).await?;
+                Ok(GuidedObservation::default())
+            }
+            GuidedAction::FillRef { reference, value } => {
+                self.click_or_fill(reference, Some(value)).await?;
+                Ok(GuidedObservation::default())
+            }
+            GuidedAction::Screenshot => {
+                let value = self
+                    .send(
+                        "Page.captureScreenshot",
+                        serde_json::json!({"format":"png"}),
+                    )
+                    .await?;
+                let encoded = value
+                    .get("data")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        ObscuraError::Evidence("CDP returned no screenshot data".into())
+                    })?;
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(encoded)
+                    .map_err(|error| ObscuraError::Evidence(error.to_string()))?;
+                if !bytes.starts_with(&[137, 80, 78, 71, 13, 10, 26, 10]) {
+                    return Err(ObscuraError::Evidence(
+                        "CDP screenshot was not PNG data".into(),
+                    ));
+                }
+                Ok(GuidedObservation {
+                    evidence: vec![EvidenceArtifact::new("screenshot", bytes)],
+                    ..Default::default()
+                })
+            }
+            GuidedAction::AssertState { .. } => Ok(GuidedObservation {
+                state: Some(self.observe_state().await?),
+                ..Default::default()
+            }),
+        }
+    }
+}

--- a/rgaa-rs/crates/rgaa-obscura/src/lib.rs
+++ b/rgaa-rs/crates/rgaa-obscura/src/lib.rs
@@ -1,22 +1,158 @@
+use base64::Engine;
+use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::net::TcpStream;
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 use tokio::sync::Semaphore;
 use tokio::time::{timeout, Instant};
-use tracing::{info, warn, error};
-use futures_util::{SinkExt, StreamExt};
-use tokio::net::TcpStream;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+use tracing::{error, info, warn};
+
+pub mod config;
+pub mod evidence;
+pub mod guided;
+pub mod results;
+
+pub use config::{
+    AdvancedRulePolicy, AnalyzeConfig, AnalyzeRequest, CookieReference, NeedsReviewPolicy,
+    PreScanAction, ScreenshotPolicy, Viewport,
+};
+pub use evidence::{EvidenceArtifact, EvidenceRef, EvidenceStore};
+pub use guided::{
+    is_stable_accessibility_reference, GuidedAction, GuidedExecutor, GuidedObservation,
+    GuidedRunResult, GuidedStep, GuidedTest, TerminationReason,
+};
+pub use results::{AnalyzePageResult, ObscuraError};
+use rgaa_core::{CriterionStatus, Finding, FindingFingerprint};
+use rgaa_rules::AxeMapper;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 const AXE_CORE_CDN: &str = "https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.9.1/axe.min.js";
+
+#[derive(Debug, Deserialize)]
+struct AxeViolationPayload {
+    id: String,
+    impact: Option<String>,
+    description: String,
+    help: Option<String>,
+    nodes: Vec<AxeNodePayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AxeNodePayload {
+    target: Vec<String>,
+    html: String,
+    #[serde(rename = "failureSummary")]
+    failure_summary: Option<String>,
+}
+
+fn validate_axe_payload(
+    value: &serde_json::Value,
+) -> Result<Vec<AxeViolationPayload>, ObscuraError> {
+    let array = value
+        .as_array()
+        .ok_or_else(|| ObscuraError::Json("axe violations must be an array".into()))?;
+    let mut payload = Vec::with_capacity(array.len());
+    for (index, item) in array.iter().enumerate() {
+        let violation =
+            serde_json::from_value::<AxeViolationPayload>(item.clone()).map_err(|error| {
+                ObscuraError::Json(format!("invalid axe violation at index {index}: {error}"))
+            })?;
+        if violation.id.trim().is_empty()
+            || violation.description.trim().is_empty()
+            || violation.nodes.is_empty()
+        {
+            return Err(ObscuraError::Json(format!(
+                "invalid axe violation at index {index}: required fields are empty"
+            )));
+        }
+        if violation
+            .nodes
+            .iter()
+            .any(|node| node.target.is_empty() || node.html.trim().is_empty())
+        {
+            return Err(ObscuraError::Json(format!(
+                "invalid axe violation at index {index}: malformed node"
+            )));
+        }
+        payload.push(violation);
+    }
+    Ok(payload)
+}
+
+fn findings_from_axe(
+    url: &str,
+    value: &serde_json::Value,
+    evidence: &[rgaa_core::EvidenceRef],
+) -> Result<Vec<Finding>, ObscuraError> {
+    let payload = validate_axe_payload(value)?;
+    let normalized =
+        serde_json::to_string(value).map_err(|error| ObscuraError::Json(error.to_string()))?;
+    let mapped = AxeMapper::map(&normalized);
+    let mut findings = Vec::new();
+    for violation in payload {
+        let mut criteria = mapped
+            .iter()
+            .filter(|(_, criterion)| {
+                criterion
+                    .violations
+                    .iter()
+                    .any(|item| item.rule_id == violation.id)
+            })
+            .map(|(criterion_id, _)| criterion_id.clone())
+            .collect::<Vec<_>>();
+        criteria.sort();
+        if criteria.is_empty() {
+            criteria.push("unmapped".into());
+        }
+        for (node_index, node) in violation.nodes.iter().enumerate() {
+            for criterion_id in &criteria {
+                let target = node.target.join(" | ");
+                let mut finding =
+                    Finding::new(format!("rgaa-{criterion_id}-{}-{node_index}", violation.id));
+                finding.rule = violation.id.clone();
+                finding.criterion_id = (criterion_id != "unmapped").then(|| criterion_id.clone());
+                finding.url = url.into();
+                finding.target = target;
+                finding.html = Some(node.html.clone());
+                finding.details = node
+                    .failure_summary
+                    .clone()
+                    .or_else(|| Some(violation.description.clone()));
+                finding.status = CriterionStatus::Fail;
+                finding.severity = violation.impact.clone().or_else(|| Some("unknown".into()));
+                finding.description = Some(violation.description.clone());
+                finding.remediation = violation.help.clone();
+                finding.evidence = evidence.to_vec();
+                finding.source = "axe-core".into();
+                findings.push(finding);
+            }
+        }
+    }
+    findings.sort_by_key(|finding| {
+        (
+            finding.id.clone(),
+            FindingFingerprint::from_finding(finding),
+        )
+    });
+    Ok(findings)
+}
 
 pub struct ObscuraBridge {
     binary_path: String,
     server_port: u16,
     server_process: Option<Child>,
+}
+
+impl Default for ObscuraBridge {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ObscuraBridge {
@@ -41,6 +177,399 @@ impl ObscuraBridge {
         self
     }
 
+    /// Analyze one page using the structured audit contract.
+    ///
+    /// Request validation failures are returned as [`ObscuraError`]. Browser
+    /// failures are returned in the page envelope so callers cannot mistake a
+    /// failed page for a clean page.
+    pub async fn analyze(
+        &self,
+        request: &AnalyzeRequest,
+    ) -> Result<AnalyzePageResult, ObscuraError> {
+        request.validate_supported()?;
+        let started = Instant::now();
+        let axe_source = match timeout(
+            Duration::from_millis(request.config.timeout_ms),
+            self.fetch_axe_source(),
+        )
+        .await
+        {
+            Ok(Ok(source)) => source,
+            Ok(Err(error)) => {
+                return Ok(AnalyzePageResult::failed(
+                    &request.url,
+                    Self::classify_error(error),
+                    started.elapsed().as_millis() as u64,
+                ))
+            }
+            Err(_) => {
+                return Ok(AnalyzePageResult::failed(
+                    &request.url,
+                    ObscuraError::Timeout("timed out fetching axe-core".into()),
+                    started.elapsed().as_millis() as u64,
+                ))
+            }
+        };
+        let mut attempt = 0;
+        let (raw, evidence) = loop {
+            let result = timeout(
+                Duration::from_millis(request.config.timeout_ms),
+                self.run_configured_axe(request, &axe_source),
+            )
+            .await;
+            match result {
+                Ok(Ok(result)) => break result,
+                Ok(Err(_error)) if attempt < usize::from(request.config.retry_limit) => {
+                    attempt += 1;
+                    continue;
+                }
+                Ok(Err(error)) => {
+                    return Ok(AnalyzePageResult::failed(
+                        &request.url,
+                        error,
+                        started.elapsed().as_millis() as u64,
+                    ))
+                }
+                Err(_) if attempt < usize::from(request.config.retry_limit) => {
+                    attempt += 1;
+                    continue;
+                }
+                Err(_) => {
+                    return Ok(AnalyzePageResult::failed(
+                        &request.url,
+                        ObscuraError::Timeout(format!(
+                            "analysis timed out after {} ms",
+                            request.config.timeout_ms
+                        )),
+                        started.elapsed().as_millis() as u64,
+                    ))
+                }
+            }
+        };
+        let violations = match serde_json::from_str::<serde_json::Value>(&raw) {
+            Ok(violations) => violations,
+            Err(error) => {
+                return Ok(AnalyzePageResult::failed(
+                    &request.url,
+                    ObscuraError::Json(error.to_string()),
+                    started.elapsed().as_millis() as u64,
+                ))
+            }
+        };
+        let findings = match findings_from_axe(&request.url, &violations, &evidence) {
+            Ok(findings) => findings,
+            Err(error) => {
+                return Ok(AnalyzePageResult::failed(
+                    &request.url,
+                    error,
+                    started.elapsed().as_millis() as u64,
+                ))
+            }
+        };
+
+        let completed = !evidence.is_empty();
+        Ok(AnalyzePageResult {
+            url: request.url.clone(),
+            findings,
+            evidence,
+            errors: Vec::new(),
+            completed,
+            duration_ms: started.elapsed().as_millis() as u64,
+        })
+    }
+
+    /// Execute a versioned guided test through the Obscura browser adapter.
+    pub async fn run_guided_test(
+        &self,
+        test: &GuidedTest,
+    ) -> Result<GuidedRunResult, ObscuraError> {
+        let mut executor = guided::ObscuraGuidedExecutor::connect(self).await?;
+        let root = std::env::temp_dir()
+            .join("rgaa-guided-evidence")
+            .join(&test.id);
+        let store = EvidenceStore::new(root);
+        let result = test.run(&mut executor, Some(&store)).await;
+        let cleanup = executor.close().await;
+        match (result, cleanup) {
+            (Ok(result), Ok(())) => Ok(result),
+            (Ok(_), Err(error)) => Err(error),
+            (Err(error), _) => Err(error),
+        }
+    }
+
+    fn classify_error(error: String) -> ObscuraError {
+        let lower = error.to_ascii_lowercase();
+        if lower.contains("timed out") || lower.contains("timeout") {
+            ObscuraError::Timeout(error)
+        } else if lower.contains("navigation") || lower.contains("load") {
+            ObscuraError::Navigation(error)
+        } else if lower.contains("websocket") || lower.contains("cdp") {
+            ObscuraError::CdpTransport(error)
+        } else if lower.contains("json") || lower.contains("result") {
+            ObscuraError::Json(error)
+        } else if lower.contains("screenshot")
+            || lower.contains("evidence")
+            || lower.contains("dom evidence")
+        {
+            ObscuraError::Evidence(error)
+        } else if lower.contains("missing secret") || lower.contains("policy") {
+            ObscuraError::PolicyDenied(error)
+        } else if lower.contains("unsupported") {
+            ObscuraError::UnsupportedConfiguration(error)
+        } else if lower.contains("failed to spawn") {
+            ObscuraError::ProcessStartup(error)
+        } else {
+            ObscuraError::Evaluation(error)
+        }
+    }
+
+    async fn run_configured_axe(
+        &self,
+        request: &AnalyzeRequest,
+        axe_source: &str,
+    ) -> Result<(String, Vec<rgaa_core::EvidenceRef>), ObscuraError> {
+        let ws_url = self
+            .get_browser_ws_url()
+            .await
+            .map_err(Self::classify_error)?;
+        let (mut ws, _) = connect_async(&ws_url)
+            .await
+            .map_err(|error| ObscuraError::CdpTransport(error.to_string()))?;
+        let target_id = Self::cdp_send(
+            &mut ws,
+            "Target.createTarget",
+            serde_json::json!({"url": request.url}),
+        )
+        .await
+        .map_err(Self::classify_error)?
+        .get("targetId")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| ObscuraError::CdpTransport("missing target id".into()))?
+        .to_owned();
+        let session_id = Self::cdp_send(
+            &mut ws,
+            "Target.attachToTarget",
+            serde_json::json!({"targetId": target_id, "flatten": true}),
+        )
+        .await
+        .map_err(Self::classify_error)?
+        .get("sessionId")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| ObscuraError::CdpTransport("missing session id".into()))?
+        .to_owned();
+
+        let outcome = self
+            .run_axe_core_configured(&mut ws, &session_id, request, axe_source)
+            .await;
+        let cleanup = Self::cleanup_target(&mut ws, &session_id, &target_id).await;
+        match (outcome.map_err(Self::classify_error), cleanup) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(_), Err(error)) => Err(Self::classify_error(error)),
+            (Err(error), _) => Err(error),
+        }
+    }
+
+    async fn run_axe_core_configured(
+        &self,
+        ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        session_id: &str,
+        request: &AnalyzeRequest,
+        axe_source: &str,
+    ) -> Result<(String, Vec<rgaa_core::EvidenceRef>), String> {
+        Self::wait_for_load(
+            ws,
+            session_id,
+            Duration::from_millis(request.config.timeout_ms),
+        )
+        .await?;
+        Self::cdp_send_session(
+            ws,
+            session_id,
+            "Emulation.setDeviceMetricsOverride",
+            serde_json::json!({
+                "width": request.config.viewport.width,
+                "height": request.config.viewport.height,
+                "deviceScaleFactor": 1,
+                "mobile": request.config.profile == "mobile"
+            }),
+        )
+        .await?;
+        self.apply_cookies(ws, session_id, request).await?;
+        self.apply_pre_scan_actions(ws, session_id, request).await?;
+        let inject = Self::cdp_send_session(
+            ws,
+            session_id,
+            "Runtime.evaluate",
+            serde_json::json!({"expression": format!("(function() {{ {} }})()", axe_source)}),
+        )
+        .await?;
+        if inject.get("exceptionDetails").is_some() {
+            return Err("axe-core injection threw an exception".into());
+        }
+        let axe_argument = request
+            .config
+            .selector
+            .as_ref()
+            .map(|selector| serde_json::to_string(selector).map_err(|error| error.to_string()))
+            .transpose()?;
+        let expression = match axe_argument {
+            Some(selector) => format!("axe.run({selector})"),
+            None => "axe.run()".into(),
+        };
+        let result = Self::cdp_send_session(
+            ws,
+            session_id,
+            "Runtime.evaluate",
+            serde_json::json!({"expression": expression, "awaitPromise": true, "returnByValue": true}),
+        )
+        .await?;
+        let raw = Self::validate_axe_result(&result)?;
+        let violations = serde_json::from_str::<serde_json::Value>(&raw)
+            .map_err(|error| format!("invalid axe JSON: {error}"))?;
+        let evidence = self
+            .capture_evidence(ws, session_id, request, &violations)
+            .await?;
+        Ok((raw, evidence))
+    }
+
+    async fn apply_cookies(
+        &self,
+        ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        session_id: &str,
+        request: &AnalyzeRequest,
+    ) -> Result<(), String> {
+        if request.config.cookie_references.is_empty() {
+            return Ok(());
+        }
+        Self::cdp_send_session(ws, session_id, "Network.enable", serde_json::json!({})).await?;
+        for cookie in &request.config.cookie_references {
+            let key = cookie
+                .name
+                .chars()
+                .map(|character| {
+                    if character.is_ascii_alphanumeric() {
+                        character.to_ascii_uppercase()
+                    } else {
+                        '_'
+                    }
+                })
+                .collect::<String>();
+            let value = std::env::var(format!("RGAA_COOKIE_{key}"))
+                .map_err(|_| format!("missing secret for cookie reference '{}'", cookie.name))?;
+            let mut params = serde_json::json!({
+                "name": cookie.name,
+                "value": value,
+                "url": request.url,
+            });
+            if let Some(domain) = &cookie.domain {
+                params["domain"] = serde_json::Value::String(domain.clone());
+            }
+            let result =
+                Self::cdp_send_session(ws, session_id, "Network.setCookie", params).await?;
+            if result.get("success").and_then(|value| value.as_bool()) == Some(false) {
+                return Err(format!(
+                    "browser rejected cookie reference '{}'",
+                    cookie.name
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    async fn apply_pre_scan_actions(
+        &self,
+        ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        session_id: &str,
+        request: &AnalyzeRequest,
+    ) -> Result<(), String> {
+        for action in &request.config.pre_scan_actions {
+            let (selector, body) = match action {
+                PreScanAction::Click { selector } => {
+                    (selector, "element.click(); return true;".to_string())
+                }
+                PreScanAction::Fill { selector, value } => {
+                    let value = serde_json::to_string(value).map_err(|error| error.to_string())?;
+                    (
+                        selector,
+                        format!(
+                            "element.value = {value}; element.dispatchEvent(new Event('input', {{bubbles:true}})); element.dispatchEvent(new Event('change', {{bubbles:true}})); return true;"
+                        ),
+                    )
+                }
+            };
+            let selector = serde_json::to_string(selector).map_err(|error| error.to_string())?;
+            let expression = format!(
+                "(() => {{ const element = document.querySelector({selector}); if (!element) throw new Error('pre-scan selector not found'); {body} }})()"
+            );
+            let result = Self::cdp_send_session(
+                ws,
+                session_id,
+                "Runtime.evaluate",
+                serde_json::json!({"expression": expression, "returnByValue": true}),
+            )
+            .await?;
+            if result.get("exceptionDetails").is_some() {
+                return Err("pre-scan action evaluation failed".into());
+            }
+        }
+        Ok(())
+    }
+
+    async fn capture_evidence(
+        &self,
+        ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        session_id: &str,
+        request: &AnalyzeRequest,
+        violations: &serde_json::Value,
+    ) -> Result<Vec<rgaa_core::EvidenceRef>, String> {
+        let dom = Self::cdp_send_session(
+            ws,
+            session_id,
+            "Runtime.evaluate",
+            serde_json::json!({
+                "expression": "document.documentElement.outerHTML",
+                "returnByValue": true
+            }),
+        )
+        .await?;
+        let dom = dom
+            .get("result")
+            .and_then(|value| value.get("value"))
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| "DOM evidence was not returned by the browser".to_string())?;
+        let mut evidence = vec![Self::evidence_ref("dom_snapshot", dom.as_bytes())];
+        let should_screenshot = match request.config.screenshot_policy {
+            ScreenshotPolicy::None => false,
+            ScreenshotPolicy::Always => true,
+            ScreenshotPolicy::OnFailure => {
+                violations.as_array().is_some_and(|items| !items.is_empty())
+            }
+        };
+        if should_screenshot {
+            let screenshot = Self::cdp_send_session(
+                ws,
+                session_id,
+                "Page.captureScreenshot",
+                serde_json::json!({"format": "png"}),
+            )
+            .await?;
+            let data = screenshot
+                .get("data")
+                .and_then(|value| value.as_str())
+                .ok_or_else(|| "screenshot evidence was not returned by the browser".to_string())?;
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(data)
+                .map_err(|error| format!("invalid screenshot evidence: {error}"))?;
+            evidence.push(Self::evidence_ref("screenshot", &bytes));
+        }
+        Ok(evidence)
+    }
+
+    fn evidence_ref(kind: &str, bytes: &[u8]) -> rgaa_core::EvidenceRef {
+        let digest = Sha256::digest(bytes);
+        rgaa_core::EvidenceRef::new(kind, format!("sha256:{digest:x}"))
+    }
+
     /// Start the obscura CDP server as a background process
     pub async fn start_server(&mut self) -> Result<(), String> {
         info!(port = self.server_port, "Starting Obscura CDP server");
@@ -59,7 +588,12 @@ impl ObscuraBridge {
 
         // Wait for server to be ready
         for i in 0..50 {
-            if let Ok(resp) = reqwest::get(&format!("http://127.0.0.1:{}/json/version", self.server_port)).await {
+            if let Ok(resp) = reqwest::get(&format!(
+                "http://127.0.0.1:{}/json/version",
+                self.server_port
+            ))
+            .await
+            {
                 if resp.status().is_success() {
                     info!(attempt = i, "Obscura CDP server ready");
                     return Ok(());
@@ -81,15 +615,20 @@ impl ObscuraBridge {
 
     /// Get the browser-level WebSocket URL from /json/version
     async fn get_browser_ws_url(&self) -> Result<String, String> {
-        let resp = reqwest::get(&format!("http://127.0.0.1:{}/json/version", self.server_port))
-            .await
-            .map_err(|e| format!("Failed to get CDP version: {e}"))?;
+        let resp = reqwest::get(&format!(
+            "http://127.0.0.1:{}/json/version",
+            self.server_port
+        ))
+        .await
+        .map_err(|e| format!("Failed to get CDP version: {e}"))?;
 
-        let version: serde_json::Value = resp.json()
+        let version: serde_json::Value = resp
+            .json()
             .await
             .map_err(|e| format!("Failed to parse CDP version: {e}"))?;
 
-        version["webSocketDebuggerUrl"].as_str()
+        version["webSocketDebuggerUrl"]
+            .as_str()
             .map(|s| s.to_string())
             .ok_or_else(|| "No webSocketDebuggerUrl in /json/version".to_string())
     }
@@ -116,7 +655,11 @@ impl ObscuraBridge {
     ///
     /// This avoids re-downloading axe-core per URL when batching. The created CDP
     /// target is always detached/closed on every exit path (success or error).
-    pub(crate) async fn run_axe_with_script(&self, url: &str, axe_source: &str) -> Result<String, String> {
+    pub(crate) async fn run_axe_with_script(
+        &self,
+        url: &str,
+        axe_source: &str,
+    ) -> Result<String, String> {
         // 1. Connect to browser-level WebSocket
         let ws_url = self.get_browser_ws_url().await?;
         let (mut ws, _) = connect_async(&ws_url)
@@ -125,9 +668,14 @@ impl ObscuraBridge {
 
         // 2. Create a new target and get its ID
         let target_id = {
-            let resp = Self::cdp_send(&mut ws, "Target.createTarget", serde_json::json!({
-                "url": url,
-            })).await?;
+            let resp = Self::cdp_send(
+                &mut ws,
+                "Target.createTarget",
+                serde_json::json!({
+                    "url": url,
+                }),
+            )
+            .await?;
             resp.get("targetId")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| "No targetId in createTarget response".to_string())?
@@ -136,10 +684,15 @@ impl ObscuraBridge {
 
         // 3. Attach to the target and get session ID
         let session_id = {
-            let resp = Self::cdp_send(&mut ws, "Target.attachToTarget", serde_json::json!({
-                "targetId": target_id,
-                "flatten": true,
-            })).await?;
+            let resp = Self::cdp_send(
+                &mut ws,
+                "Target.attachToTarget",
+                serde_json::json!({
+                    "targetId": target_id,
+                    "flatten": true,
+                }),
+            )
+            .await?;
             resp.get("sessionId")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| "No sessionId in attachToTarget response".to_string())?
@@ -149,16 +702,12 @@ impl ObscuraBridge {
         // 4. Run the actual evaluation, then always clean up the target.
         let outcome = self.run_axe_core(&mut ws, &session_id, axe_source).await;
 
-        // Best-effort cleanup: detach then close the target, then close the socket.
-        let _ = Self::cdp_send_session(&mut ws, &session_id, "Target.detachFromTarget", serde_json::json!({
-            "sessionId": session_id,
-        })).await;
-        let _ = Self::cdp_send(&mut ws, "Target.closeTarget", serde_json::json!({
-            "targetId": target_id,
-        })).await;
-        let _ = ws.close(None).await;
-
-        outcome
+        let cleanup = Self::cleanup_target(&mut ws, &session_id, &target_id).await;
+        match (outcome, cleanup) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(_), Err(error)) => Err(error),
+            (Err(error), _) => Err(error),
+        }
     }
 
     /// Inner axe-core evaluation: wait for navigation, inject axe, then run it.
@@ -172,20 +721,32 @@ impl ObscuraBridge {
         Self::wait_for_load(ws, session_id, Duration::from_secs(15)).await?;
 
         // 5. Inject axe-core via script source
-        let inject = Self::cdp_send_session(ws, session_id, "Runtime.evaluate", serde_json::json!({
-            "expression": format!("(function() {{ {} }})()", axe_source),
-        })).await?;
+        let inject = Self::cdp_send_session(
+            ws,
+            session_id,
+            "Runtime.evaluate",
+            serde_json::json!({
+                "expression": format!("(function() {{ {} }})()", axe_source),
+            }),
+        )
+        .await?;
 
         if inject.get("exceptionDetails").is_some() {
             return Err("axe-core injection threw an exception".to_string());
         }
 
         // 6. Run axe.run() and capture the resolved value directly.
-        let result = Self::cdp_send_session(ws, session_id, "Runtime.evaluate", serde_json::json!({
-            "expression": "axe.run()",
-            "awaitPromise": true,
-            "returnByValue": true,
-        })).await?;
+        let result = Self::cdp_send_session(
+            ws,
+            session_id,
+            "Runtime.evaluate",
+            serde_json::json!({
+                "expression": "axe.run()",
+                "awaitPromise": true,
+                "returnByValue": true,
+            }),
+        )
+        .await?;
 
         Self::validate_axe_result(&result)
     }
@@ -243,16 +804,24 @@ impl ObscuraBridge {
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                return Err("timed out waiting for page load (loadEventFired / readyState)".to_string());
+                return Err(
+                    "timed out waiting for page load (loadEventFired / readyState)".to_string(),
+                );
             }
 
             // Issue a readyState poll when none is outstanding and the interval elapsed.
             if pending_readystate.is_none() && last_poll.elapsed() >= poll_interval {
                 last_poll = Instant::now();
-                let id = Self::cdp_issue(ws, "Runtime.evaluate", serde_json::json!({
-                    "expression": "document.readyState",
-                    "returnByValue": true,
-                }), Some(session_id)).await?;
+                let id = Self::cdp_issue(
+                    ws,
+                    "Runtime.evaluate",
+                    serde_json::json!({
+                        "expression": "document.readyState",
+                        "returnByValue": true,
+                    }),
+                    Some(session_id),
+                )
+                .await?;
                 pending_readystate = Some(id);
             }
 
@@ -297,10 +866,14 @@ impl ObscuraBridge {
                     return Err("CDP WebSocket closed while waiting for page load".to_string());
                 }
                 Ok(Some(Err(e))) => {
-                    return Err(format!("CDP WebSocket error while waiting for page load: {e}"));
+                    return Err(format!(
+                        "CDP WebSocket error while waiting for page load: {e}"
+                    ));
                 }
                 Ok(None) => {
-                    return Err("CDP WebSocket stream ended while waiting for page load".to_string());
+                    return Err(
+                        "CDP WebSocket stream ended while waiting for page load".to_string()
+                    );
                 }
                 Err(_) => {
                     // Timed out waiting for a message; re-check deadline and retry.
@@ -314,7 +887,11 @@ impl ObscuraBridge {
     ///
     /// Fetches axe-core once, then bounds concurrent `run_axe_with_script` calls
     /// with a semaphore sized by `concurrency` (treated as 1 when 0).
-    pub async fn run_axe_batch(&self, urls: &[String], concurrency: usize) -> Result<HashMap<String, String>, String> {
+    pub async fn run_axe_batch(
+        &self,
+        urls: &[String],
+        concurrency: usize,
+    ) -> Result<HashMap<String, String>, String> {
         if urls.is_empty() {
             return Ok(HashMap::new());
         }
@@ -323,8 +900,7 @@ impl ObscuraBridge {
 
         info!(
             urls = urls.len(),
-            concurrency,
-            "Running batch axe-core audit via CDP"
+            concurrency, "Running batch axe-core audit via CDP"
         );
 
         // Fetch axe-core once for the whole batch.
@@ -342,10 +918,7 @@ impl ObscuraBridge {
             let sem = Arc::clone(&sem);
 
             tokio::spawn(async move {
-                let _permit = sem
-                    .acquire()
-                    .await
-                    .expect("semaphore closed unexpectedly");
+                let _permit = sem.acquire().await.expect("semaphore closed unexpectedly");
 
                 let bridge = ObscuraBridge {
                     binary_path,
@@ -363,8 +936,12 @@ impl ObscuraBridge {
         let mut results = HashMap::new();
         while let Some((url, result)) = rx.recv().await {
             match result {
-                Ok(violations) => { results.insert(url, violations); }
-                Err(e) => { warn!(url = %url, error = %e, "axe-core failed"); }
+                Ok(violations) => {
+                    results.insert(url, violations);
+                }
+                Err(e) => {
+                    warn!(url = %url, error = %e, "axe-core failed");
+                }
             }
         }
 
@@ -503,7 +1080,10 @@ impl ObscuraBridge {
     ) -> Result<HashMap<String, serde_json::Value>, String> {
         let script = Self::build_page_context_script();
 
-        info!(urls = urls.len(), concurrency, "Running batch page context extraction via CLI");
+        info!(
+            urls = urls.len(),
+            concurrency, "Running batch page context extraction via CLI"
+        );
 
         let output = timeout(Duration::from_secs(300), async {
             Command::new(&self.binary_path)
@@ -623,6 +1203,30 @@ impl ObscuraBridge {
         Self::cdp_wait_response(ws, id).await
     }
 
+    async fn cleanup_target(
+        ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        session_id: &str,
+        target_id: &str,
+    ) -> Result<(), String> {
+        let detach = Self::cdp_send(
+            ws,
+            "Target.detachFromTarget",
+            serde_json::json!({"sessionId": session_id}),
+        )
+        .await
+        .map(|_| ());
+        let close = Self::cdp_send(
+            ws,
+            "Target.closeTarget",
+            serde_json::json!({"targetId": target_id}),
+        )
+        .await
+        .map(|_| ());
+        let socket = ws.close(None).await.map_err(|error| error.to_string());
+
+        detach.and(close).and(socket)
+    }
+
     /// Build and send a CDP message, returning the generated request id.
     async fn cdp_issue(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
@@ -645,7 +1249,7 @@ impl ObscuraBridge {
             msg["sessionId"] = serde_json::Value::String(sid.to_string());
         }
 
-        ws.send(Message::Text(msg.to_string().into()))
+        ws.send(Message::Text(msg.to_string()))
             .await
             .map_err(|e| format!("CDP send failed: {e}"))?;
 
@@ -662,7 +1266,10 @@ impl ObscuraBridge {
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                return Err(format!("CDP timeout waiting for response id={}", expected_id));
+                return Err(format!(
+                    "CDP timeout waiting for response id={}",
+                    expected_id
+                ));
             }
 
             match tokio::time::timeout(remaining, ws.next()).await {
@@ -674,7 +1281,10 @@ impl ObscuraBridge {
                                 if let Some(error) = value.get("error") {
                                     return Err(format!("CDP error: {}", error));
                                 }
-                                return Ok(value.get("result").cloned().unwrap_or(serde_json::Value::Null));
+                                return Ok(value
+                                    .get("result")
+                                    .cloned()
+                                    .unwrap_or(serde_json::Value::Null));
                             }
                         }
                         // Otherwise it's an event, skip it
@@ -683,7 +1293,12 @@ impl ObscuraBridge {
                 Ok(Some(Ok(Message::Close(_)))) => return Err("CDP WebSocket closed".to_string()),
                 Ok(Some(Err(e))) => return Err(format!("CDP WebSocket error: {e}")),
                 Ok(None) => return Err("CDP WebSocket stream ended".to_string()),
-                Err(_) => return Err(format!("CDP timeout waiting for response id={}", expected_id)),
+                Err(_) => {
+                    return Err(format!(
+                        "CDP timeout waiting for response id={}",
+                        expected_id
+                    ))
+                }
                 _ => {}
             }
         }
@@ -746,7 +1361,9 @@ mod tests {
         // A broken axe source throws during injection, which must surface as Err
         // rather than being silently treated as a clean (empty) result.
         let broken = "throw new Error('boom')";
-        let result = bridge.run_axe_with_script("https://example.com", broken).await;
+        let result = bridge
+            .run_axe_with_script("https://example.com", broken)
+            .await;
 
         bridge.stop_server().await;
 
@@ -755,5 +1372,64 @@ mod tests {
             "broken evaluation should surface an Err, got: {:?}",
             result.ok()
         );
+    }
+
+    #[tokio::test]
+    async fn analyze_rejects_invalid_request_before_starting_browser_work() {
+        let bridge = ObscuraBridge::new();
+        let request = AnalyzeRequest {
+            url: "file:///secret.html".into(),
+            config: AnalyzeConfig::default(),
+        };
+
+        assert!(matches!(
+            bridge.analyze(&request).await,
+            Err(ObscuraError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn browser_failures_are_classified_as_page_errors() {
+        let result = AnalyzePageResult::failed(
+            "https://unreachable.test",
+            ObscuraBridge::classify_error("timed out waiting for page load".into()),
+            1,
+        );
+
+        assert!(!result.completed);
+        assert_eq!(result.errors[0].code, "timeout");
+    }
+
+    #[test]
+    fn malformed_axe_items_are_rejected_before_mapping() {
+        let payload = serde_json::json!([{}]);
+        assert!(matches!(
+            validate_axe_payload(&payload),
+            Err(ObscuraError::Json(_))
+        ));
+    }
+
+    #[test]
+    fn axe_findings_preserve_context_and_have_stable_order() {
+        let payload = serde_json::json!([{
+            "id": "image-alt",
+            "impact": "critical",
+            "description": "Images must have alternate text",
+            "help": "Ensure alt text",
+            "nodes": [{"target": ["#z"], "html": "<img id=\"z\">"}, {"target": ["#a"], "html": "<img id=\"a\">"}]
+        }]);
+        let evidence = vec![rgaa_core::EvidenceRef::new("dom_snapshot", "sha256:x")];
+        let findings = findings_from_axe("https://example.test", &payload, &evidence)
+            .expect("valid axe payload");
+        assert_eq!(findings.len(), 14);
+        assert!(findings.windows(2).all(|pair| pair[0].id <= pair[1].id));
+        let finding = findings
+            .iter()
+            .find(|finding| finding.target == "#a")
+            .expect("target preserved");
+        assert_eq!(finding.html.as_deref(), Some("<img id=\"a\">"));
+        assert_eq!(finding.criterion_id.as_deref(), Some("1.1"));
+        assert_eq!(finding.source, "axe-core");
+        assert_eq!(finding.evidence, evidence);
     }
 }

--- a/rgaa-rs/crates/rgaa-obscura/src/results.rs
+++ b/rgaa-rs/crates/rgaa-obscura/src/results.rs
@@ -1,0 +1,128 @@
+use rgaa_core::{EvidenceRef, Finding, PageError};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Error)]
+pub enum ObscuraError {
+    #[error("failed to start obscura: {0}")]
+    ProcessStartup(String),
+    #[error("CDP transport failed: {0}")]
+    CdpTransport(String),
+    #[error("navigation failed: {0}")]
+    Navigation(String),
+    #[error("page evaluation failed: {0}")]
+    Evaluation(String),
+    #[error("invalid analysis request: {0}")]
+    Validation(String),
+    #[error("operation timed out: {0}")]
+    Timeout(String),
+    #[error("evidence capture failed: {0}")]
+    Evidence(String),
+    #[error("invalid JSON: {0}")]
+    Json(String),
+    #[error("unsupported analysis configuration: {0}")]
+    UnsupportedConfiguration(String),
+    #[error("analysis policy denied: {0}")]
+    PolicyDenied(String),
+}
+
+impl ObscuraError {
+    pub fn page_error(&self) -> PageError {
+        let code = match self {
+            Self::Navigation(_) => "navigation",
+            Self::Evaluation(_) => "evaluation",
+            Self::Timeout(_) => "timeout",
+            Self::Evidence(_) => "evidence",
+            Self::CdpTransport(_) => "cdp_transport",
+            Self::ProcessStartup(_) => "process_startup",
+            Self::Validation(_) => "validation",
+            Self::Json(_) => "json",
+            Self::UnsupportedConfiguration(_) => "unsupported_configuration",
+            Self::PolicyDenied(_) => "policy_denied",
+        };
+        PageError {
+            code: code.into(),
+            message: self.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AnalyzePageResult {
+    pub url: String,
+    pub findings: Vec<Finding>,
+    pub evidence: Vec<EvidenceRef>,
+    pub errors: Vec<PageError>,
+    pub completed: bool,
+    pub duration_ms: u64,
+}
+
+impl AnalyzePageResult {
+    pub fn failed(url: impl Into<String>, error: ObscuraError, duration_ms: u64) -> Self {
+        Self {
+            url: url.into(),
+            findings: Vec::new(),
+            evidence: Vec::new(),
+            errors: vec![error.page_error()],
+            completed: false,
+            duration_ms,
+        }
+    }
+
+    pub fn is_clean_complete(&self) -> bool {
+        self.completed && self.errors.is_empty() && !self.evidence.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_page_is_not_a_clean_result() {
+        let result = AnalyzePageResult::failed(
+            "https://bad.test",
+            ObscuraError::Navigation("unreachable".into()),
+            12,
+        );
+        assert!(!result.completed);
+        assert!(result.findings.is_empty());
+        assert_eq!(result.errors[0].code, "navigation");
+        let json = serde_json::to_string(&result).expect("result serializes");
+        assert!(json.contains("unreachable"));
+    }
+
+    #[test]
+    fn all_typed_errors_keep_distinct_serialized_codes() {
+        let errors = [
+            (ObscuraError::ProcessStartup("x".into()), "process_startup"),
+            (ObscuraError::CdpTransport("x".into()), "cdp_transport"),
+            (ObscuraError::Navigation("x".into()), "navigation"),
+            (ObscuraError::Json("x".into()), "json"),
+            (ObscuraError::Evaluation("x".into()), "evaluation"),
+            (ObscuraError::Timeout("x".into()), "timeout"),
+            (ObscuraError::Evidence("x".into()), "evidence"),
+            (
+                ObscuraError::UnsupportedConfiguration("x".into()),
+                "unsupported_configuration",
+            ),
+            (ObscuraError::PolicyDenied("x".into()), "policy_denied"),
+        ];
+        for (error, code) in errors {
+            assert_eq!(error.page_error().code, code);
+        }
+    }
+
+    #[test]
+    fn clean_result_requires_evidence() {
+        let result = AnalyzePageResult {
+            url: "https://example.test".into(),
+            findings: Vec::new(),
+            evidence: Vec::new(),
+            errors: Vec::new(),
+            completed: true,
+            duration_ms: 1,
+        };
+        assert!(!result.is_clean_complete());
+    }
+}

--- a/rgaa-rs/crates/rgaa-obscura/tests/guided_tests.rs
+++ b/rgaa-rs/crates/rgaa-obscura/tests/guided_tests.rs
@@ -1,0 +1,322 @@
+use rgaa_obscura::{
+    is_stable_accessibility_reference, EvidenceArtifact, EvidenceStore, GuidedExecutor,
+    GuidedObservation, GuidedRunResult, GuidedStep, GuidedTest, TerminationReason,
+};
+use rgaa_obscura::{GuidedAction, ObscuraError};
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+struct FakeExecutor {
+    calls: Vec<GuidedAction>,
+    results: VecDeque<Result<GuidedObservation, ObscuraError>>,
+}
+
+struct StatefulExecutor {
+    value: Option<String>,
+}
+
+impl GuidedExecutor for StatefulExecutor {
+    async fn execute(&mut self, action: &GuidedAction) -> Result<GuidedObservation, ObscuraError> {
+        match action {
+            GuidedAction::FillRef { value, .. } => {
+                self.value = Some(value.clone());
+                Ok(GuidedObservation::default())
+            }
+            GuidedAction::AssertState { .. } => Ok(GuidedObservation {
+                state: Some(serde_json::json!({"value": self.value})),
+                ..Default::default()
+            }),
+            _ => Ok(GuidedObservation::default()),
+        }
+    }
+}
+
+impl FakeExecutor {
+    fn new(results: impl IntoIterator<Item = Result<GuidedObservation, ObscuraError>>) -> Self {
+        Self {
+            calls: Vec::new(),
+            results: results.into_iter().collect(),
+        }
+    }
+}
+
+impl GuidedExecutor for FakeExecutor {
+    async fn execute(&mut self, action: &GuidedAction) -> Result<GuidedObservation, ObscuraError> {
+        self.calls.push(action.clone());
+        self.results
+            .pop_front()
+            .unwrap_or_else(|| Ok(GuidedObservation::default()))
+    }
+}
+
+fn test_case(steps: Vec<GuidedStep>) -> GuidedTest {
+    GuidedTest {
+        id: "keyboard-flow".into(),
+        version: 1,
+        preconditions: vec!["page loaded".into()],
+        steps,
+        criterion_mapping: vec!["7.3".into()],
+        evidence_requirements: vec!["tree".into(), "screenshot".into()],
+    }
+}
+
+fn no_required_evidence(mut test: GuidedTest) -> GuidedTest {
+    test.evidence_requirements.clear();
+    test
+}
+
+#[tokio::test]
+async fn mutating_actions_are_followed_by_observation() {
+    let mut executor = FakeExecutor::new([
+        Ok(GuidedObservation::default()),
+        Ok(GuidedObservation::tree(["dialog-close"])),
+        Ok(GuidedObservation::default()),
+    ]);
+    let test = no_required_evidence(test_case(vec![
+        GuidedStep::PressKey { key: "Tab".into() },
+        GuidedStep::AccessibilityTree,
+        GuidedStep::Screenshot,
+    ]));
+
+    let result = test.run(&mut executor, None).await.expect("run succeeds");
+
+    assert!(result.is_pass());
+    assert_eq!(
+        executor.calls[0],
+        GuidedAction::PressKey { key: "Tab".into() }
+    );
+    assert_eq!(executor.calls[1], GuidedAction::AccessibilityTree);
+    assert_eq!(result.completed_steps, 3);
+    assert_eq!(result.criterion_mapping, vec!["7.3"]);
+    assert_eq!(result.action_trace.len(), 3);
+}
+
+#[tokio::test]
+async fn missing_reference_is_incomplete_and_records_unanalyzed_target() {
+    let mut executor = FakeExecutor::new([Err(ObscuraError::Evaluation(
+        "missing element reference: save-button".into(),
+    ))]);
+    let test = test_case(vec![
+        GuidedStep::ClickRef {
+            reference: "save-button".into(),
+        },
+        GuidedStep::AccessibilityTree,
+    ]);
+
+    let result = test
+        .run(&mut executor, None)
+        .await
+        .expect("run returns envelope");
+
+    assert!(!result.is_pass());
+    assert_eq!(
+        result.terminated_reason,
+        TerminationReason::MissingReference
+    );
+    assert_eq!(
+        result.unanalyzed_elements,
+        vec![
+            "save-button",
+            "accessibility-tree",
+            "evidence:tree",
+            "evidence:screenshot"
+        ]
+    );
+    assert!(result.manual_review_required);
+}
+
+#[tokio::test]
+async fn assertion_failure_cannot_serialize_as_pass() {
+    let mut executor = FakeExecutor::new([
+        Ok(GuidedObservation::default()),
+        Err(ObscuraError::Evaluation("assertion failed".into())),
+    ]);
+    let test = test_case(vec![
+        GuidedStep::FillRef {
+            reference: "name".into(),
+            value: "Ada".into(),
+        },
+        GuidedStep::AssertState {
+            expected: serde_json::json!({"name": "Ada"}),
+        },
+    ]);
+
+    let result = test
+        .run(&mut executor, None)
+        .await
+        .expect("run returns envelope");
+
+    assert!(!result.is_pass());
+    assert_eq!(result.terminated_reason, TerminationReason::AssertionFailed);
+    assert!(!serde_json::to_string(&result)
+        .expect("result serializes")
+        .contains("\"status\":\"pass\""));
+}
+
+#[tokio::test]
+async fn observed_state_mismatch_preserves_assertion_failure() {
+    let mut executor = FakeExecutor::new([Ok(GuidedObservation {
+        state: Some(serde_json::json!({"actual": true})),
+        ..Default::default()
+    })]);
+    let test = test_case(vec![GuidedStep::AssertState {
+        expected: serde_json::json!({"expected": true}),
+    }]);
+
+    let result = test
+        .run(&mut executor, None)
+        .await
+        .expect("run returns envelope");
+
+    assert_eq!(result.terminated_reason, TerminationReason::AssertionFailed);
+    assert!(!result.is_pass());
+}
+
+#[tokio::test]
+async fn stateful_executor_preserves_typed_values_between_steps() {
+    let mut executor = StatefulExecutor { value: None };
+    let mut test = test_case(vec![
+        GuidedStep::FillRef {
+            reference: "ax:42".into(),
+            value: "Ada".into(),
+        },
+        GuidedStep::AssertState {
+            expected: serde_json::json!({"value": "Ada"}),
+        },
+    ]);
+    test.evidence_requirements.clear();
+
+    let result = test.run(&mut executor, None).await.expect("run succeeds");
+
+    assert!(result.is_pass());
+    assert_eq!(executor.value.as_deref(), Some("Ada"));
+}
+
+#[test]
+fn accessibility_references_are_stable_backend_node_ids() {
+    assert!(is_stable_accessibility_reference("ax:42"));
+    assert!(is_stable_accessibility_reference(
+        "ax-role=textbox;name=Name"
+    ));
+    assert!(!is_stable_accessibility_reference("#save-button"));
+    assert!(!is_stable_accessibility_reference("button:3"));
+}
+
+#[tokio::test]
+async fn invalid_action_ordering_is_incomplete() {
+    let mut executor = FakeExecutor::new([]);
+    let test = test_case(vec![GuidedStep::ClickRef {
+        reference: "ax:42".into(),
+    }]);
+
+    let result = test
+        .run(&mut executor, None)
+        .await
+        .expect("run returns envelope");
+
+    assert_eq!(result.terminated_reason, TerminationReason::InvalidOrdering);
+    assert!(!result.is_pass());
+    assert!(executor.calls.is_empty());
+}
+
+#[tokio::test]
+async fn failed_step_marks_all_remaining_steps_unanalyzed() {
+    let mut executor =
+        FakeExecutor::new([Err(ObscuraError::Navigation("navigation failed".into()))]);
+    let test = test_case(vec![
+        GuidedStep::Navigate {
+            url: "https://example.test".into(),
+        },
+        GuidedStep::AccessibilityTree,
+        GuidedStep::PressKey { key: "Tab".into() },
+        GuidedStep::AccessibilityTree,
+        GuidedStep::ClickRef {
+            reference: "ax:42".into(),
+        },
+        GuidedStep::AccessibilityTree,
+    ]);
+
+    let result = test
+        .run(&mut executor, None)
+        .await
+        .expect("run returns envelope");
+
+    assert_eq!(result.terminated_reason, TerminationReason::NavigationError);
+    assert_eq!(result.unanalyzed_elements.len(), 6);
+}
+
+#[test]
+fn screenshot_evidence_requires_a_real_png_signature() {
+    let root = std::env::temp_dir().join(format!("rgaa-png-{}", uuid::Uuid::new_v4()));
+    let store = EvidenceStore::new(root.clone());
+    let invalid = store.write(EvidenceArtifact::new("screenshot", b"html".to_vec()));
+    assert!(matches!(invalid, Err(ObscuraError::Evidence(_))));
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn required_evidence_is_part_of_pass_semantics() {
+    let test = test_case(vec![]);
+    let result = GuidedRunResult {
+        terminated_reason: TerminationReason::Completed,
+        criterion_mapping: test.criterion_mapping,
+        evidence_requirements: test.evidence_requirements,
+        ..Default::default()
+    };
+    assert!(!result.is_pass());
+}
+
+#[tokio::test]
+async fn keyboard_trap_and_timeout_are_incomplete() {
+    for error in [
+        ObscuraError::Evaluation("keyboard trap detected".into()),
+        ObscuraError::Timeout("step timed out".into()),
+    ] {
+        let mut executor = if matches!(error, ObscuraError::Timeout(_)) {
+            FakeExecutor::new([Err(error.clone()), Err(error.clone()), Err(error)])
+        } else {
+            FakeExecutor::new([Err(error)])
+        };
+        let test = test_case(vec![
+            GuidedStep::PressKey { key: "Tab".into() },
+            GuidedStep::AccessibilityTree,
+        ]);
+        let result = test
+            .run(&mut executor, None)
+            .await
+            .expect("run returns envelope");
+        assert!(!result.is_pass());
+        assert!(matches!(
+            result.terminated_reason,
+            TerminationReason::KeyboardTrap | TerminationReason::Timeout
+        ));
+    }
+}
+
+#[test]
+fn evidence_store_writes_content_hashes_and_replays_deterministically() {
+    let root = std::env::temp_dir().join(format!("rgaa-evidence-{}", uuid::Uuid::new_v4()));
+    let store = EvidenceStore::new(root.clone());
+    let artifact = EvidenceArtifact::new(
+        "screenshot",
+        [vec![137, 80, 78, 71, 13, 10, 26, 10], b"png-bytes".to_vec()].concat(),
+    );
+
+    let first = store.write(artifact.clone()).expect("write evidence");
+    let second = store.write(artifact).expect("replay evidence");
+
+    assert_eq!(first.sha256, second.sha256);
+    assert_eq!(first.path, second.path);
+    assert!(PathBuf::from(&first.path).exists());
+    assert!(first.sha256.starts_with("sha256:"));
+    assert!(std::fs::read(&first.path)
+        .expect("read screenshot")
+        .starts_with(&[137, 80, 78, 71, 13, 10, 26, 10]));
+    std::fs::remove_dir_all(root).expect("remove test evidence");
+}
+
+#[test]
+fn guided_result_defaults_to_incomplete_without_completion() {
+    let result = GuidedRunResult::default();
+    assert!(!result.is_pass());
+}

--- a/rgaa-rs/crates/rgaa-obscura/tests/integration_test.rs
+++ b/rgaa-rs/crates/rgaa-obscura/tests/integration_test.rs
@@ -1,39 +1,52 @@
 use rgaa_obscura::ObscuraBridge;
+use rgaa_obscura::{AnalyzeConfig, AnalyzeRequest, PreScanAction, ScreenshotPolicy, Viewport};
+use rgaa_obscura::{GuidedStep, GuidedTest, TerminationReason};
 
 #[tokio::test]
 async fn test_obscura_bridge_sync() {
     let bridge = ObscuraBridge::new();
     let result = bridge.extract_page_context("https://example.com").await;
     println!("Page context result: {:?}", result);
-    assert!(result.is_ok(), "Failed to extract page context: {:?}", result.err());
-    
+    assert!(
+        result.is_ok(),
+        "Failed to extract page context: {:?}",
+        result.err()
+    );
+
     let context = result.unwrap();
     println!("Context: {:?}", context);
-    assert!(context.get("title").is_some(), "Missing title in page context");
+    assert!(
+        context.get("title").is_some(),
+        "Missing title in page context"
+    );
 }
 
 #[tokio::test]
 async fn test_obscura_bridge_axe_via_cdp() {
     let mut bridge = ObscuraBridge::new().with_port(9223);
-    
+
     // Start CDP server
     let server_result = bridge.start_server().await;
     println!("Server start result: {:?}", server_result);
-    assert!(server_result.is_ok(), "Failed to start server: {:?}", server_result.err());
-    
+    assert!(
+        server_result.is_ok(),
+        "Failed to start server: {:?}",
+        server_result.err()
+    );
+
     // Run axe-core
     let result = bridge.run_axe("https://example.com").await;
     println!("Axe result: {:?}", result);
-    
+
     // Stop server
     bridge.stop_server().await;
-    
+
     assert!(result.is_ok(), "Failed to run axe: {:?}", result.err());
 
     // The returned string must be valid JSON and a JSON array (violations).
     let ax = result.unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&ax)
-        .expect("axe result must be parseable JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&ax).expect("axe result must be parseable JSON");
     assert!(parsed.is_array(), "axe result must be a JSON array");
 }
 
@@ -43,7 +56,11 @@ async fn test_obscura_bridge_axe_batch_multiple_urls() {
 
     let server_result = bridge.start_server().await;
     println!("Server start result: {:?}", server_result);
-    assert!(server_result.is_ok(), "Failed to start server: {:?}", server_result.err());
+    assert!(
+        server_result.is_ok(),
+        "Failed to start server: {:?}",
+        server_result.err()
+    );
 
     let urls = vec![
         "https://example.com".to_string(),
@@ -54,13 +71,20 @@ async fn test_obscura_bridge_axe_batch_multiple_urls() {
 
     bridge.stop_server().await;
 
-    assert!(results.is_ok(), "Failed to run axe batch: {:?}", results.err());
+    assert!(
+        results.is_ok(),
+        "Failed to run axe batch: {:?}",
+        results.err()
+    );
     let results = results.unwrap();
     assert_eq!(results.len(), 2, "axe batch must return one entry per URL");
     for (url, ax) in &results {
         let parsed: serde_json::Value = serde_json::from_str(ax)
             .unwrap_or_else(|e| panic!("axe batch result for {url} must be JSON: {e}"));
-        assert!(parsed.is_array(), "axe batch result for {url} must be a JSON array");
+        assert!(
+            parsed.is_array(),
+            "axe batch result for {url} must be a JSON array"
+        );
     }
 }
 
@@ -69,7 +93,11 @@ async fn test_obscura_bridge_extract_page_context_batch() {
     let mut bridge = ObscuraBridge::new().with_port(9225);
 
     let server_result = bridge.start_server().await;
-    assert!(server_result.is_ok(), "Failed to start server: {:?}", server_result.err());
+    assert!(
+        server_result.is_ok(),
+        "Failed to start server: {:?}",
+        server_result.err()
+    );
 
     let urls = vec![
         "https://example.com".to_string(),
@@ -80,11 +108,22 @@ async fn test_obscura_bridge_extract_page_context_batch() {
 
     bridge.stop_server().await;
 
-    assert!(results.is_ok(), "Failed to extract page context batch: {:?}", results.err());
+    assert!(
+        results.is_ok(),
+        "Failed to extract page context batch: {:?}",
+        results.err()
+    );
     let results = results.unwrap();
-    assert_eq!(results.len(), 2, "page context batch must return one entry per URL");
+    assert_eq!(
+        results.len(),
+        2,
+        "page context batch must return one entry per URL"
+    );
     for (url, ctx) in &results {
-        assert!(ctx.get("title").is_some(), "missing title in page context for {url}");
+        assert!(
+            ctx.get("title").is_some(),
+            "missing title in page context for {url}"
+        );
     }
 }
 
@@ -96,7 +135,10 @@ async fn test_obscura_bridge_extract_page_context_batch() {
 async fn test_obscura_bridge_axe_batch_performance() {
     // run_axe_batch drives per-URL CDP sessions, so the CDP server must be up.
     let mut bridge = ObscuraBridge::new().with_port(9226);
-    assert!(bridge.start_server().await.is_ok(), "failed to start CDP server");
+    assert!(
+        bridge.start_server().await.is_ok(),
+        "failed to start CDP server"
+    );
 
     let urls: Vec<String> = vec![
         "https://example.com".to_string(),
@@ -114,13 +156,173 @@ async fn test_obscura_bridge_axe_batch_performance() {
 
     assert!(results.is_ok(), "axe batch failed: {:?}", results.err());
     let results = results.unwrap();
-    assert_eq!(results.len(), urls.len(), "axe batch must return one entry per URL");
+    assert_eq!(
+        results.len(),
+        urls.len(),
+        "axe batch must return one entry per URL"
+    );
     for (url, ax) in &results {
         let parsed: serde_json::Value = serde_json::from_str(ax)
             .unwrap_or_else(|e| panic!("axe batch result for {url} must be JSON: {e}"));
-        assert!(parsed.is_array(), "axe batch result for {url} must be a JSON array");
+        assert!(
+            parsed.is_array(),
+            "axe batch result for {url} must be a JSON array"
+        );
     }
 
     // Guard against a regression to sequential/blocking execution.
-    assert!(elapsed.as_secs() < 60, "axe batch unexpectedly slow: {elapsed:?}");
+    assert!(
+        elapsed.as_secs() < 60,
+        "axe batch unexpectedly slow: {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_structured_analyze_applies_configuration_and_captures_evidence() {
+    let mut bridge = ObscuraBridge::new().with_port(9227);
+    assert!(
+        bridge.start_server().await.is_ok(),
+        "failed to start CDP server"
+    );
+
+    let config = AnalyzeConfig {
+        viewport: Viewport {
+            width: 375,
+            height: 812,
+        },
+        selector: Some("body".into()),
+        pre_scan_actions: vec![PreScanAction::Click {
+            selector: "body".into(),
+        }],
+        screenshot_policy: ScreenshotPolicy::Always,
+        timeout_ms: 30_000,
+        retry_limit: 1,
+        ..Default::default()
+    };
+    let request = AnalyzeRequest {
+        url: "https://example.com".into(),
+        config,
+    };
+
+    let result = bridge.analyze(&request).await;
+    bridge.stop_server().await;
+
+    let result = result.expect("structured analysis request should be accepted");
+    assert!(
+        result.completed,
+        "configured analysis must complete with evidence: {result:?}"
+    );
+    assert!(
+        result.errors.is_empty(),
+        "configured analysis returned errors: {:?}",
+        result.errors
+    );
+    assert!(result
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "dom_snapshot"));
+    assert!(result
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "screenshot"));
+}
+
+#[tokio::test]
+async fn test_guided_test_captures_trace_tree_screenshot_and_mapping() {
+    let mut bridge = ObscuraBridge::new().with_port(9228);
+    bridge
+        .start_server()
+        .await
+        .expect("failed to start guided-test CDP server");
+    let test = GuidedTest {
+        id: "worker-keyboard-flow".into(),
+        version: 1,
+        preconditions: vec!["page is reachable".into()],
+        steps: vec![
+            GuidedStep::Navigate {
+                url: "https://example.com".into(),
+            },
+            GuidedStep::AccessibilityTree,
+            GuidedStep::Screenshot,
+        ],
+        criterion_mapping: vec!["12.9".into()],
+        evidence_requirements: vec!["tree".into(), "screenshot".into()],
+    };
+
+    let result = bridge
+        .run_guided_test(&test)
+        .await
+        .expect("guided run returns an envelope");
+    bridge.stop_server().await;
+
+    assert_eq!(result.terminated_reason, TerminationReason::Completed);
+    assert_eq!(result.action_trace.len(), 3);
+    assert_eq!(result.criterion_mapping, vec!["12.9"]);
+    assert!(result
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "tree"));
+    assert!(result
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "screenshot"));
+    let screenshot = result
+        .evidence
+        .iter()
+        .find(|evidence| evidence.kind == "screenshot")
+        .expect("screenshot evidence");
+    assert!(std::fs::read(&screenshot.path)
+        .expect("read screenshot evidence")
+        .starts_with(&[137, 80, 78, 71, 13, 10, 26, 10]));
+}
+
+#[tokio::test]
+async fn test_guided_stateful_ax_ref_fill_and_observed_state() {
+    let mut bridge = ObscuraBridge::new().with_port(9229);
+    bridge
+        .start_server()
+        .await
+        .expect("failed to start stateful guided-test CDP server");
+    let url = "data:text/html,%3C!doctype%20html%3E%3Cform%3E%3Clabel%3EName%3Cinput%20aria-label%3D%22Name%22%20name%3D%22name%22%3E%3C/label%3E%3C/form%3E";
+    let test = GuidedTest {
+        id: "worker-stateful-fill".into(),
+        version: 1,
+        preconditions: vec!["form is loaded".into()],
+        steps: vec![
+            GuidedStep::Navigate { url: url.into() },
+            GuidedStep::AccessibilityTree,
+            GuidedStep::FillRef {
+                reference: "ax-role=textbox;name=Name".into(),
+                value: "Ada".into(),
+            },
+            GuidedStep::AssertState {
+                expected: serde_json::json!({
+                    "values": [{"id": "", "name": "name", "value": "Ada"}]
+                }),
+            },
+        ],
+        criterion_mapping: vec!["11.1".into()],
+        evidence_requirements: vec!["tree".into()],
+    };
+
+    let result = bridge
+        .run_guided_test(&test)
+        .await
+        .expect("stateful guided run returns an envelope");
+    let targets: serde_json::Value = reqwest::get("http://127.0.0.1:9229/json/list")
+        .await
+        .expect("read CDP targets")
+        .json()
+        .await
+        .expect("parse CDP targets");
+    bridge.stop_server().await;
+
+    assert!(result.is_pass(), "state did not persist: {result:?}");
+    assert_eq!(result.completed_steps, 4);
+    assert_eq!(result.terminated_reason, TerminationReason::Completed);
+    assert!(!targets
+        .as_array()
+        .expect("target list is an array")
+        .iter()
+        .any(|target| target.get("url").and_then(serde_json::Value::as_str) == Some(url)));
 }


### PR DESCRIPTION
## Summary
- AuditBundle with schema v1.0 validation, finding fingerprints (FNV-1a), evidence refs
- Structured Obscura analysis contract (AnalyzeConfig/AnalyzePageResult)
- Reproducible guided tests with stateful CDP executor
- PNG evidence capture, keyboard trap detection, AX tree refs

## Files (17)
- `rgaa-rs/crates/rgaa-core/` — Domain types, criteria catalog, audit bundle validation
- `rgaa-rs/crates/rgaa-obscura/` — Analysis contract, guided test executor, evidence capture

## Tests
- 15 unit tests across core contracts and guided execution

## Summary by Sourcery

Establish versioned audit and Obscura analysis contracts with reproducible browser testing and verifiable evidence capture.

New Features:
- Introduce versioned audit bundles with schema validation, structured findings, checkpoints, evidence references, and stable finding fingerprints.
- Add a structured Obscura page-analysis contract with configurable browser analysis and typed result/error envelopes.
- Add versioned guided browser tests with state assertions, accessibility-tree references, action traces, keyboard-trap detection, retries, and manual-review outcomes.
- Capture and persist hashed DOM, accessibility-tree, and PNG screenshot evidence.

Bug Fixes:
- Ensure browser and analysis failures are represented as incomplete page results rather than clean audit results.
- Improve CDP target cleanup across analysis and guided execution paths.

Enhancements:
- Standardize criterion status serialization and expand supported audit statuses.
- Validate analysis inputs and reject unsupported configurations before browser execution.
- Map axe-core violations into contextual, deterministically ordered RGAA findings.

Build:
- Expand the Rust workspace with Obscura, remediation, MCP, and CLI crates and add supporting dependencies.

Tests:
- Add unit, guided-execution, evidence, and integration coverage for contract validation, stateful flows, evidence capture, failure handling, and CDP analysis.