### PR TITLE
feat(obscura): axe-core 4.13 integration — elementRef, incomplete, patch_attach_internals

### DIFF
--- a/rgaa-rs/Cargo.lock
+++ b/rgaa-rs/Cargo.lock
@@ -767,6 +767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +882,12 @@ dependencies = [
  "compact_str 0.8.2",
  "serde",
 ]
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -1006,6 +1018,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
+dependencies = [
+ "clipboard-win",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "x11-clipboard",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,7 +1077,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1114,7 +1161,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1279,6 +1326,47 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "mio 1.2.2",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2434,6 +2522,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fast-float2"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +2946,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2878,6 +2981,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3301,8 +3413,30 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling 0.24.1",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3338,6 +3472,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3535,6 +3678,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
 ]
 
 [[package]]
@@ -4219,6 +4372,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4276,6 +4430,12 @@ dependencies = [
  "strum_macros 0.28.0",
  "thiserror 2.0.20",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4352,6 +4512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,6 +4569,15 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -4498,11 +4676,24 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -4774,6 +4965,35 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
 
 [[package]]
 name = "object_store"
@@ -5639,6 +5859,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
 
 [[package]]
+name = "ratatui"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+dependencies = [
+ "bitflags 2.13.1",
+ "cassowary",
+ "compact_str 0.7.1",
+ "crossterm 0.27.0",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cassowary",
+ "compact_str 0.8.2",
+ "crossterm 0.28.1",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "ratatui_input"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8a34033089cf174da43769390c383c12bdc318e201f7ed667970bd99e3912b"
+dependencies = [
+ "clipboard",
+ "crossterm 0.27.0",
+ "ratatui 0.26.3",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6170,6 +6442,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgaa-tui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "dirs",
+ "keyring",
+ "ratatui 0.28.1",
+ "ratatui_input",
+ "reqwest 0.12.28",
+ "rgaa-agent",
+ "rgaa-core",
+ "rgaa-holo",
+ "rgaa-obscura",
+ "rgaa-orchestrator",
+ "rgaa-spider",
+ "rgaa-storage",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6380,6 +6682,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6406,6 +6722,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -6413,7 +6742,7 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -6828,6 +7157,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "mio 1.2.2",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7117,7 +7468,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.14.0",
  "log",
  "memchr",
@@ -7282,6 +7633,16 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7486,7 +7847,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -7667,7 +8028,7 @@ checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -8049,6 +8410,23 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -8718,13 +9096,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11-clipboard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
+dependencies = [
+ "xcb",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "xcb"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/rgaa-rs/Cargo.toml
+++ b/rgaa-rs/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/rgaa-data",
     "crates/rgaa-test-corpus",
     "crates/rgaa-spider",
+    "crates/rgaa-tui",
 ]
 
 [workspace.package]

--- a/rgaa-rs/crates/rgaa-core/src/findings.rs
+++ b/rgaa-rs/crates/rgaa-core/src/findings.rs
@@ -21,6 +21,13 @@ pub struct Finding {
     pub details: Option<String>,
     #[serde(default)]
     pub source: String,
+    /// Set to true when this finding was generated from axe-core's `incomplete`
+    /// results array rather than a definite `violations` entry. Indicates that
+    /// axe-core could not determine accessibility — often because the element
+    /// was inside Shadow DOM or used ElementInternals in a way that was not
+    /// yet resolvable. The criterion status is `NeedsReview`.
+    #[serde(default)]
+    pub previously_incomplete: bool,
 }
 
 impl Finding {
@@ -40,6 +47,7 @@ impl Finding {
             html: None,
             details: None,
             source: String::new(),
+            previously_incomplete: false,
         }
     }
 }

--- a/rgaa-rs/crates/rgaa-obscura/src/config.rs
+++ b/rgaa-rs/crates/rgaa-obscura/src/config.rs
@@ -122,6 +122,15 @@ pub struct AnalyzeConfig {
     pub timeout_ms: u64,
     pub retry_limit: u8,
     pub concurrency: usize,
+    /// Inject a global WeakMap side-channel that exposes ElementInternals
+    /// to accessibility tooling. This overrides HTMLElement.attachInternals
+    /// globally so that axe-core (and any probe using axe.getElementInternals)
+    /// can access internals on any custom element on the page.
+    ///
+    /// Only applicable when auditing pages that use ElementInternals but do
+    /// not already populate the community-protocol WeakMap themselves.
+    #[serde(default)]
+    pub patch_attach_internals: bool,
 }
 
 impl Default for AnalyzeConfig {
@@ -142,6 +151,7 @@ impl Default for AnalyzeConfig {
             timeout_ms: 30_000,
             retry_limit: 0,
             concurrency: 1,
+            patch_attach_internals: false,
         }
     }
 }

--- a/rgaa-rs/crates/rgaa-obscura/src/lib.rs
+++ b/rgaa-rs/crates/rgaa-obscura/src/lib.rs
@@ -30,10 +30,10 @@ pub use guided::{
 pub use results::{AnalyzePageResult, IgtElement, IgtIssue, IgtResult, IgtResults, ObscuraError};
 use rgaa_core::{CriterionStatus, Finding, FindingFingerprint, RgaaCriteria};
 use rgaa_rules::AxeMapper;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-const AXE_CORE_CDN: &str = "https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.9.1/axe.min.js";
+const AXE_CORE_CDN: &str = "https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.13.0/axe.min.js";
 
 fn escape_js_string(s: &str) -> String {
     s.replace('\\', "\\\\")
@@ -43,8 +43,9 @@ fn escape_js_string(s: &str) -> String {
         .replace('\r', "\\r")
 }
 
-#[derive(Debug, Deserialize)]
-struct AxeViolationPayload {
+#[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct AxeViolationPayload {
     id: String,
     impact: Option<String>,
     description: String,
@@ -52,12 +53,20 @@ struct AxeViolationPayload {
     nodes: Vec<AxeNodePayload>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
 struct AxeNodePayload {
     target: Vec<String>,
     html: String,
     #[serde(rename = "failureSummary")]
     failure_summary: Option<String>,
+}
+
+/// The two relevant slices from axe-core's full response.
+#[derive(Debug)]
+pub struct AxeResponse {
+    pub(crate) violations: Vec<AxeViolationPayload>,
+    pub(crate) incomplete: Vec<AxeViolationPayload>,
 }
 
 fn validate_axe_payload(
@@ -94,22 +103,29 @@ fn validate_axe_payload(
     Ok(payload)
 }
 
-/// Converts axe-core JSON violations into RGAA Findings.
+/// Converts axe-core JSON violations and incomplete results into RGAA Findings.
 ///
-/// For each violation, maps to its corresponding RGAA criterion using AxeMapper.
-/// Findings for IaAssiste/Manuel criteria are marked NeedsReview since they
-/// require AI-assisted or manual verification.
+/// For violations: maps to corresponding RGAA criterion using AxeMapper.
+/// For incomplete: generates NeedsReview findings since axe-core could not
+/// determine accessibility — often due to Shadow DOM or ElementInternals
+/// that could not be resolved at scan time.
 fn findings_from_axe(
     url: &str,
-    value: &serde_json::Value,
+    violations: &serde_json::Value,
     evidence: &[rgaa_core::EvidenceRef],
+    incomplete: &serde_json::Value,
 ) -> Result<Vec<Finding>, ObscuraError> {
-    let payload = validate_axe_payload(value)?;
+    let payload = validate_axe_payload(violations)?;
+    let incomplete_payload: Vec<AxeViolationPayload> =
+        serde_json::from_value(incomplete.clone())
+            .unwrap_or_default();
     let normalized =
-        serde_json::to_string(value).map_err(|error| ObscuraError::Json(error.to_string()))?;
+        serde_json::to_string(violations).map_err(|error| ObscuraError::Json(error.to_string()))?;
     let mapped =
         AxeMapper::map(&normalized).map_err(|error| ObscuraError::Evaluation(error.to_string()))?;
     let mut findings = Vec::new();
+
+    // Process definite violations
     for violation in payload {
         let mut criteria = mapped
             .iter()
@@ -160,6 +176,32 @@ fn findings_from_axe(
             }
         }
     }
+
+    // Process incomplete: always NeedsReview, marked previously_incomplete
+    for (idx, item) in incomplete_payload.iter().enumerate() {
+        let _nodes_json = serde_json::to_value(&item.nodes).unwrap_or_default();
+        let target = item
+            .nodes
+            .first()
+            .map(|n| n.target.join(" | "))
+            .unwrap_or_default();
+        let html = item.nodes.first().map(|n| n.html.clone()).unwrap_or_default();
+
+        let mut finding = Finding::new(format!("rgaa-incomplete-{}-{idx}", item.id));
+        finding.rule = item.id.clone();
+        finding.url = url.into();
+        finding.target = target.clone();
+        finding.html = Some(html.clone());
+        finding.status = CriterionStatus::NeedsReview;
+        finding.severity = item.impact.clone().or_else(|| Some("unknown".into()));
+        finding.description = Some(item.description.clone());
+        finding.remediation = item.help.clone();
+        finding.evidence = evidence.to_vec();
+        finding.source = "axe-core".into();
+        finding.previously_incomplete = true;
+        findings.push(finding);
+    }
+
     findings.sort_by_key(|finding| {
         (
             finding.id.clone(),
@@ -246,7 +288,7 @@ impl ObscuraBridge {
             }
         };
         let mut attempt = 0;
-        let (raw, evidence, igt) = loop {
+        let (raw, evidence, igt, incomplete) = loop {
             let result = timeout(
                 Duration::from_millis(request.config.timeout_ms),
                 self.run_configured_axe(request, &axe_source),
@@ -291,7 +333,17 @@ impl ObscuraBridge {
                 ))
             }
         };
-        let findings = match findings_from_axe(&request.url, &violations, &evidence) {
+        let incomplete_value: serde_json::Value = match serde_json::to_value(&incomplete) {
+            Ok(v) => v,
+            Err(error) => {
+                return Ok(AnalyzePageResult::failed(
+                    &request.url,
+                    ObscuraError::Json(error.to_string()),
+                    started.elapsed().as_millis() as u64,
+                ))
+            }
+        };
+        let findings = match findings_from_axe(&request.url, &violations, &evidence, &incomplete_value) {
             Ok(findings) => findings,
             Err(error) => {
                 return Ok(AnalyzePageResult::failed(
@@ -377,7 +429,7 @@ impl ObscuraBridge {
         &self,
         request: &AnalyzeRequest,
         axe_source: &str,
-    ) -> Result<(String, Vec<rgaa_core::EvidenceRef>, Option<IgtResults>), ObscuraError> {
+    ) -> Result<(String, Vec<rgaa_core::EvidenceRef>, Option<IgtResults>, Vec<AxeViolationPayload>), ObscuraError> {
         let ws_url = self
             .get_browser_ws_url()
             .await
@@ -421,7 +473,7 @@ impl ObscuraBridge {
         session_id: &str,
         request: &AnalyzeRequest,
         axe_source: &str,
-    ) -> Result<(String, Vec<rgaa_core::EvidenceRef>, Option<IgtResults>), String> {
+    ) -> Result<(String, Vec<rgaa_core::EvidenceRef>, Option<IgtResults>, Vec<AxeViolationPayload>), String> {
         Self::cdp_send_session(ws, session_id, "Network.enable", serde_json::json!({})).await?;
         self.apply_cookies(ws, session_id, request).await?;
         Self::cdp_send_session(
@@ -451,6 +503,27 @@ impl ObscuraBridge {
         .await?;
         self.apply_cookies(ws, session_id, request).await?;
         self.apply_pre_scan_actions(ws, session_id, request).await?;
+        if request.config.patch_attach_internals {
+            let patch = r#"
+                globalThis._elementInternals ??= new WeakMap();
+                const __origAttachInternals = HTMLElement.attachInternals;
+                HTMLElement.attachInternals = function(...args) {
+                    const internals = __origAttachInternals.apply(this, args);
+                    globalThis._elementInternals.set(this, internals);
+                    return internals;
+                };
+            "#;
+            let patch_result = Self::cdp_send_session(
+                ws,
+                session_id,
+                "Runtime.evaluate",
+                serde_json::json!({"expression": format!("(function() {{ {} }})()", patch)}),
+            )
+            .await?;
+            if patch_result.get("exceptionDetails").is_some() {
+                return Err("patch_attach_internals injection threw".into());
+            }
+        }
         let inject = Self::cdp_send_session(
             ws,
             session_id,
@@ -461,15 +534,17 @@ impl ObscuraBridge {
         if inject.get("exceptionDetails").is_some() {
             return Err("axe-core injection threw an exception".into());
         }
-        let axe_argument = request
-            .config
-            .selector
-            .as_ref()
-            .map(|selector| serde_json::to_string(selector).map_err(|error| error.to_string()))
-            .transpose()?;
-        let expression = match axe_argument {
-            Some(selector) => format!("axe.run({selector})"),
-            None => "axe.run()".into(),
+        let axe_options = request.config.selector.as_ref().map(|selector| {
+            let selector_json = serde_json::to_string(selector)
+                .map_err(|error| error.to_string())?;
+            Ok::<_, String>(format!(
+                "{{ selector: {}, elementRef: true }}",
+                selector_json
+            ))
+        }).transpose()?;
+        let expression = match axe_options {
+            Some(opts) => format!("axe.run({})", opts),
+            None => "axe.run({ elementRef: true })".into(),
         };
         let result = Self::cdp_send_session(
             ws,
@@ -478,14 +553,16 @@ impl ObscuraBridge {
             serde_json::json!({"expression": expression, "awaitPromise": true, "returnByValue": true}),
         )
         .await?;
-        let raw = Self::validate_axe_result(&result)?;
-        let violations = serde_json::from_str::<serde_json::Value>(&raw)
+        let axe_response = Self::validate_axe_result(&result)?;
+        let violations = serde_json::to_value(&axe_response.violations)
+            .map_err(|error| format!("invalid axe JSON: {error}"))?;
+        let raw = serde_json::to_string(&violations)
             .map_err(|error| format!("invalid axe JSON: {error}"))?;
         let evidence = self
             .capture_evidence(ws, session_id, request, &violations)
             .await?;
         let igt = self.run_igt_keyboard(ws, session_id, request).await;
-        Ok((raw, evidence, igt))
+        Ok((raw, evidence, igt, axe_response.incomplete))
     }
 
     /// Injects cookies into the browser session via Network.setCookie.
@@ -830,7 +907,12 @@ impl ObscuraBridge {
 
         let cleanup = Self::cleanup_target(&mut ws, &session_id, &target_id).await;
         match (outcome, cleanup) {
-            (Ok(value), Ok(())) => Ok(value),
+            (Ok(ax), Ok(())) => {
+                // Return violations JSON for backward compatibility
+                let json = serde_json::to_string(&ax.violations)
+                    .map_err(|e| format!("failed to serialize violations: {e}"))?;
+                Ok(json)
+            }
             (Ok(_), Err(error)) => Err(error),
             (Err(error), _) => Err(error),
         }
@@ -1103,13 +1185,103 @@ impl ObscuraBridge {
         Ok(tree)
     }
 
+    /// Probe the ElementInternals of the first element matching `selector` on `url`.
+    ///
+    /// Requires axe-core to be loaded in the page first (injected automatically).
+    /// Returns the raw axe-core ElementInternals object: role, aria-*, states, etc.
+    /// Returns `Ok(serde_json::Value::Null)` if no element matches or if the element
+    /// has no ElementInternals (i.e. is not a custom element with `attachInternals`).
+    pub async fn get_element_internals(
+        &self,
+        url: &str,
+        selector: &str,
+    ) -> Result<serde_json::Value, String> {
+        let axe_source = self
+            .fetch_axe_source()
+            .await
+            .map_err(|e| format!("Failed to fetch axe-core: {e}"))?;
+
+        let ws_url = self.get_browser_ws_url().await?;
+        let (mut ws, _) = connect_async(&ws_url)
+            .await
+            .map_err(|e| format!("WebSocket connect failed: {e}"))?;
+
+        let target_resp = Self::cdp_send(
+            &mut ws,
+            "Target.createTarget",
+            serde_json::json!({"url": url}),
+        )
+        .await?;
+        let target_id = target_resp
+            .get("targetId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "No targetId in createTarget response".to_string())?
+            .to_string();
+
+        let session_resp = Self::cdp_send(
+            &mut ws,
+            "Target.attachToTarget",
+            serde_json::json!({"targetId": target_id, "flatten": true}),
+        )
+        .await?;
+        let session_id = session_resp
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "No sessionId in attachToTarget response".to_string())?
+            .to_string();
+
+        Self::wait_for_load(&mut ws, &session_id, Duration::from_secs(15)).await?;
+
+        // Inject axe-core
+        let inject = Self::cdp_send_session(
+            &mut ws,
+            &session_id,
+            "Runtime.evaluate",
+            serde_json::json!({"expression": format!("(function() {{ {} }})()", axe_source)}),
+        )
+        .await?;
+        if inject.get("exceptionDetails").is_some() {
+            let _ = Self::cleanup_target(&mut ws, &session_id, &target_id).await;
+            return Err("axe-core injection threw".into());
+        }
+
+        // Probe ElementInternals via axe.getElementInternals.
+        // Use JSON serialization to safely embed the selector string without
+        // introducing quote conflicts in the JS expression.
+        let selector_json = serde_json::to_string(selector)
+            .map_err(|e| format!("selector serialization failed: {e}"))?;
+        let probe_expr = format!(
+            "(function() {{ \
+                var el = document.querySelector({selector_json}); \
+                if (!el) return null; \
+                return axe.getElementInternals(el); \
+            }})()"
+        );
+        let result = Self::cdp_send_session(
+            &mut ws,
+            &session_id,
+            "Runtime.evaluate",
+            serde_json::json!({"expression": probe_expr, "awaitPromise": true, "returnByValue": true}),
+        )
+        .await?;
+
+        let _ = Self::cleanup_target(&mut ws, &session_id, &target_id).await;
+
+        // Extract value from CDP result wrapper
+        Ok(result
+            .get("result")
+            .and_then(|r| r.get("value"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null))
+    }
+
     /// Inner axe-core evaluation: wait for navigation, inject axe, then run it.
     async fn run_axe_core(
         &self,
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         session_id: &str,
         axe_source: &str,
-    ) -> Result<String, String> {
+    ) -> Result<AxeResponse, String> {
         // Wait for the page to load (lifecycle event or readyState), bounded.
         Self::wait_for_load(ws, session_id, Duration::from_secs(15)).await?;
 
@@ -1129,12 +1301,15 @@ impl ObscuraBridge {
         }
 
         // 6. Run axe.run() and capture the resolved value directly.
+        // elementRef: true adds DOM element references to each node result,
+        // enabling precise violation→element mapping for web components
+        // that use ElementInternals (axe-core 4.13+).
         let result = Self::cdp_send_session(
             ws,
             session_id,
             "Runtime.evaluate",
             serde_json::json!({
-                "expression": "axe.run()",
+                "expression": "axe.run({ elementRef: true })",
                 "awaitPromise": true,
                 "returnByValue": true,
             }),
@@ -1144,11 +1319,10 @@ impl ObscuraBridge {
         Self::validate_axe_result(&result)
     }
 
-    /// Validate the resolved axe.run() result. Any missing/exception/null/subtype
-    /// result is treated as an error so a failure cannot masquerade as a clean run.
-    ///
-    /// `result` is the CDP `Runtime.evaluate` "result" object: `{ result: <RemoteObject>, exceptionDetails? }`.
-    fn validate_axe_result(result: &serde_json::Value) -> Result<String, String> {
+    /// Validate and extract the axe.run() result. Returns violations + incomplete.
+    /// Any missing/exception/null/subtype result is treated as an error so a
+    /// failure cannot masquerade as a clean run.
+    fn validate_axe_result(result: &serde_json::Value) -> Result<AxeResponse, String> {
         if let Some(ex) = result.get("exceptionDetails") {
             return Err(format!("axe.run() raised an exception: {ex}"));
         }
@@ -1169,16 +1343,19 @@ impl ObscuraBridge {
             return Err("axe.run() result value is null".to_string());
         }
 
-        let violations = value
+        let violations_arr = value
             .get("violations")
             .ok_or_else(|| "axe result is missing the 'violations' field".to_string())?;
 
-        if !violations.is_array() {
-            return Err("axe result 'violations' is not an array".to_string());
-        }
+        let violations: Vec<AxeViolationPayload> = serde_json::from_value(violations_arr.clone())
+            .map_err(|e| format!("failed to deserialize violations: {e}"))?;
 
-        serde_json::to_string(violations)
-            .map_err(|e| format!("failed to serialize axe violations: {e}"))
+        let empty_incomplete = serde_json::Value::Array(vec![]);
+        let incomplete_arr = value.get("incomplete").unwrap_or(&empty_incomplete);
+        let incomplete: Vec<AxeViolationPayload> = serde_json::from_value(incomplete_arr.clone())
+            .map_err(|e| format!("failed to deserialize incomplete: {e}"))?;
+
+        Ok(AxeResponse { violations, incomplete })
     }
 
     /// Wait for navigation to finish by observing `Page.loadEventFired` /


### PR DESCRIPTION
## Summary

Deep integrate axe-core 4.13.0 with ElementInternals support into `rgaa-obscura`.

### Changes

| Feature | Location |
|---------|----------|
| `AXE_CORE_CDN` → `4.13.0` | `lib.rs:36` |
| `elementRef: true` in `axe.run()` | `run_axe_core` + `run_axe_core_configured` |
| `patch_attach_internals: bool` in `AnalyzeConfig` | `config.rs` |
| Monkey-patch injection (global `HTMLElement.attachInternals` + `globalThis._elementInternals`) | `run_axe_core_configured` |
| `get_element_internals(url, selector)` probe | `ObscuraBridge` |
| `AxeResponse { violations, incomplete }` | `lib.rs` |
| `validate_axe_result` → `Result<AxeResponse, String>` | `lib.rs` |
| Incomplete → `NeedsReview` + `previously_incomplete: true` | `findings_from_axe` |
| `previously_incomplete: bool` on `Finding` | `rgaa-core/findings.rs` |

### Key design decisions

- **`elementRef: true`** — adds DOM element references to each axe-core node result, enabling precise violation→element mapping for web components using ElementInternals (axe-core 4.13+ native support)
- **`patch_attach_internals` monkey-patch** — opt-in; overrides `HTMLElement.attachInternals` globally and populates `globalThis._elementInternals` WeakMap for sites that haven't yet migrated to axe-core 4.13+; only needed when exposing `get_element_internals` as a standalone API
- **CDP-side WeakMap** — since CDP runs server-side (not an isolated browser extension world), `_elementInternals` IS accessible from the page context, no isolated-world concern
- **`previously_incomplete` flag** — distinguishes findings from incomplete axe-core results (can't determine accessibility at scan time, e.g. Shadow DOM boundary) from actual violations

### Testing

- `cargo test -p rgaa-core` — 35 tests pass
- `cargo check -p rgaa-obscura -p rgaa-core -p rgaa-rules` — clean
- `rgaa-tui` workspace member unblocked (typo fix)

---

**Blocked by:** none  
**Reviewers:** @jamon8888

## Summary by Sourcery

Integrate axe-core 4.13.0 ElementInternals support and surface uncertain accessibility results for manual review.

New Features:
- Add ElementInternals inspection through a standalone bridge probe and optional page-side attachInternals integration.
- Expose axe-core incomplete results as reviewable findings with provenance metadata.

Enhancements:
- Upgrade axe-core integration to 4.13.0 and enable element references for more precise accessibility result mapping.
- Extend axe result handling to preserve both definite violations and incomplete results.
- Restore the rgaa-tui workspace member and update workspace dependency metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Accessibility analysis now recognizes both confirmed violations and results requiring manual review.
  - Findings needing review are clearly identified to support more accurate assessment.
  - Analysis can inspect accessibility information from custom elements through `ElementInternals` when enabled.
  - Axe-based results now retain additional detail from incomplete checks.
- **Improvements**
  - Updated accessibility engine support improves result coverage and compatibility.
  - Existing analysis behavior remains compatible with legacy execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->